### PR TITLE
Solved MQT-DDSIM version error

### DIFF
--- a/cunqa/circuit.py
+++ b/cunqa/circuit.py
@@ -227,7 +227,7 @@ def from_json_to_qc(circuit_dict):
 
 
 
-def registers_dict(qc):
+def _registers_dict(qc):
     """
     Extracts the number of classical and quantum registers from a QuantumCircuit.
 
@@ -275,5 +275,50 @@ def registers_dict(qc):
         classical_registers[k] = counts[i]
 
     return [quantum_registers, classical_registers]
+
+def _is_parametric(circuit):
+    """
+    Function to determine weather a cirucit has gates that accept parameters, not necesarily parametric <class 'qiskit.circuit.quantumcircuit.QuantumCircuit'>.
+    For example, a circuit that is composed by hadamard and cnot gates is not a parametric circuit; but if a circuit has any of the gates defined in `parametric_gates` we
+    consider it a parametric circuit for our purposes.
+
+    Args:
+    -------
+    circuit (<class 'qiskit.circuit.quantumcircuit.QuantumCircuit'>, dict or str): the circuit from which we want to find out if it's parametric.
+
+    Return:
+    -------
+    True if the circuit is considered parametric, False if it's not.
+    """
+    parametric_gates = ["u", "u1", "u2", "u3", "rx", "ry", "rz", "crx", "cry", "crz", "cu1", "cu3", "rxx", "ryy", "rzz", "rzx", "cp", "cswap", "ccx", "crz", "cu"]
+    if isinstance(circuit, QuantumCircuit):
+        logger.debug("Possible parametric circuit is a QuantumCircuit.")
+        for instruction in circuit.data:
+            if instruction.operation.name in parametric_gates:
+                logger.debug("Parametric gate found, therefore circuit is considered parametric.")
+                return True
+        logger.debug("Parametric gate NOT found, therefore circuit is NOT considered parametric.")
+        return False
+
+    elif isinstance(circuit, dict):
+        logger.debug("Possible parametric circuit is a json.")
+        for instruction in circuit['instructions']:
+            if instruction['name'] in parametric_gates:
+                logger.debug("Parametric gate found, therefore circuit is considered parametric.")
+                return True
+        logger.debug("Parametric gate NOT found, therefore circuit is NOT considered parametric.")
+        return False
+
+    elif isinstance(circuit, str):
+        logger.debug(f"Possible parametric circuit is a QASM string. {type(circuit)}")
+
+        for line in circuit.splitlines():
+            logger.debug(f"Line: {line}")
+            line = line.strip()
+            if any(line.startswith(gate) for gate in parametric_gates):
+                logger.debug("Parametric gate found, therefore circuit is considered parametric.")
+                return True
+        logger.debug("Parametric gate NOT found, therefore circuit is NOT considered parametric.")
+        return False
 
 

--- a/cunqa/qjob.py
+++ b/cunqa/qjob.py
@@ -3,7 +3,7 @@ from qiskit import QuantumCircuit
 from qiskit.qasm2 import dumps
 from qiskit.qasm2.exceptions import QASM2Error
 from qiskit.exceptions import QiskitError
-from cunqa.circuit import qc_to_json, from_json_to_qc, registers_dict, is_parametric
+from cunqa.circuit import qc_to_json, from_json_to_qc, _registers_dict, _is_parametric
 from cunqa.transpile import transpiler, TranspilerError
 
 # importing logger
@@ -256,7 +256,7 @@ class QJob():
                 logger.debug("A QuantumCircuit was provided.")
 
                 cl_bits = sum([c.size for c in circt.cregs])
-                self._cregisters = registers_dict(circt)[1]
+                self._cregisters = _registers_dict(circt)[1]
 
                 if self._QPU.backend.simulator == "AerSimulator":
 
@@ -275,7 +275,7 @@ class QJob():
 
                 logger.debug("A QASM2 circuit was provided.")
 
-                self._cregisters = registers_dict(QuantumCircuit.from_qasm_str(circt))[1]
+                self._cregisters = _registers_dict(QuantumCircuit.from_qasm_str(circt))[1]
                 cl_bits = sum(len(k) for k in self._cregisters.values())
 
                 if self._QPU.backend.simulator == "AerSimulator":
@@ -378,6 +378,9 @@ class QJob():
         if self._result is None:
             self._future.get()
 
+        if not _is_parametric(self._circuit):
+            logger.error(f"Cannot upgrade parameters. Please check that the circuit provided has gates that accept parameters [{QJobError.__name__}].")
+            raise SystemExit # User's level
 
         if isinstance(parameters, list):
 

--- a/src/utils/parametric_circuit.hpp
+++ b/src/utils/parametric_circuit.hpp
@@ -92,7 +92,7 @@ json update_qasm_parameters(json& circuit, const std::vector<double>& params) {
     }
 
     std::string qasmCode = circuit.at("instructions");
-    std::regex paramRegex(R"((rx|ry|rz|u1|u2|u3)\(\s*(-?[0-9]*\.?[0-9]+)\s*\))");
+    std::regex paramRegex(R"((rx|ry|rz|u1|u2|u3)\(\s*([a-zA-Z0-9_]+)\s*\))");
     std::smatch match;
 
     std::string updatedQasm = qasmCode;


### PR DESCRIPTION
- Added `_is_parametric` method (Private) to check if a circuit has gates that accept parameters.
- Changed `_registers_dict` to "private".
- Added an assertion in ùpgrade_parameters` to check if the circuit accepts parameters, using new function `_is_paramteric`.
- Modified `parametric_circuit.hpp` so that munich simulator identifies correctly parametric gates even if a `np.pi` is provided.