### PR TITLE
mode HPC 

### DIFF
--- a/cunqa/bindings.cpp
+++ b/cunqa/bindings.cpp
@@ -18,7 +18,7 @@ PYBIND11_MODULE(qclient, m) {
  
         .def(py::init<const std::optional<std::string> &>(), py::arg("filepath") = std::nullopt)  // Constructor sin argumentos
  
-        .def("connect", &Client::connect, py::arg("task_id") = "", py::arg("net") = "ib0") // Metodo
+        .def("connect", &Client::connect, py::arg("task_id") = "") // Metodo
  
         .def("send_circuit", [](Client &c, const std::string& circuit) { 
             return FutureWrapper(c.send_circuit(circuit)); 

--- a/examples/example_aer.py
+++ b/examples/example_aer.py
@@ -80,22 +80,28 @@ with open(conf_file, 'r', encoding='utf-8') as archivo:
 if isinstance(datos, dict):
     claves_primer_nivel = list(datos.keys())
 
+""" from cunqa.qutils import nodeswithQPUs, infoQPUs, getQPUs
+
+print(nodeswithQPUs())
+print(infoQPUs(node_name=nodeswithQPUs()[0]))
+print(getQPUs(local=False, family_name="Exposito")) """
+
 #for clave in claves_primer_nivel:
-client = QClient(conf_file)
+""" client = QClient(conf_file)
 print("Cliente instanciado")
 
 print(type(client))
 
 print(claves_primer_nivel)
 
-client.connect(claves_primer_nivel[0])
+client.connect(claves_primer_nivel[0]) """
 
-print("Cliente: " + claves_primer_nivel[0])
+""" print("Cliente: " + claves_primer_nivel[0])
 future1 = client.send_circuit(qc)
 future2 = client.send_circuit(qc)
 
 print("Futures creados.")
 
 print("GET DEL FUTURE 1:" + future1.get())
-print("GET DEL FUTURE 2:" + future2.get())
+print("GET DEL FUTURE 2:" + future2.get()) """
 #print("RESULT DEL PARAMETERS:" + future_param.get())

--- a/src/cli/infoqpus.cpp
+++ b/src/cli/infoqpus.cpp
@@ -77,7 +77,7 @@ int main(int argc, char* argv[]) {
         }
         
         if (family_counts_per_node.find(slurm_nodename) != family_counts_per_node.end()) {
-            std::cout << "In current \033[34mNode " << slurm_nodename << "\033[0m there are the following QPUs: " << "\n";
+            std::cout << "In current \033[34mNode " << slurm_nodename << "\033[0m there are: " << "\n";
             for (auto& [family_name, number] : family_counts_per_node[slurm_nodename]) {
                 std::cout << indent << number << " QPUs with family name: " << family_name << "\n";
             }
@@ -86,7 +86,7 @@ int main(int argc, char* argv[]) {
         }
     } else {
         for (auto& [node_name, node_info] : family_counts_per_node) {
-            std::cout << "In \033[34mNode " << node_name << "\033[0m there are the following QPUs: " << "\n";
+            std::cout << "In \033[34mNode " << node_name << "\033[0m there are: " << "\n";
             for (auto& [family_name, number] : node_info) {
                 std::cout << indent << number << " QPUs with family name: " << family_name << "\n";
             }

--- a/src/cli/setup_qpus.cpp
+++ b/src/cli/setup_qpus.cpp
@@ -15,17 +15,18 @@ using json = nlohmann::json;
 
 int main(int argc, char *argv[])
 {
-    SPDLOG_LOGGER_DEBUG(logger,"Setup QPUs arguments: argc={} argv= {} {} {}", argc, argv[1], argv[2], argv[3]);
-    std::string family_name(argv[1]);
-    std::string info_path(argv[2]);
-    std::string simulator(argv[3]);
+    SPDLOG_LOGGER_DEBUG(logger,"Setup QPUs arguments: argc={} argv= {} {} {} {}", argc, argv[1], argv[2], argv[3], argv[4]);
+    std::string mode(argv[1]);
+    std::string family_name(argv[2]);
+    std::string info_path(argv[3]);
+    std::string simulator(argv[4]);
     std::string backend;
     json backend_json;
 
     json qpu_config_json = {};
     try {
-        if (argc == 5) {
-            backend = std::string(argv[4]);
+        if (argc == 6) {
+            backend = std::string(argv[5]);
             std::cout << backend << "\n";
             backend_json = json::parse(backend);
             if (backend_json.contains("fakeqmio_path")) {
@@ -41,7 +42,7 @@ int main(int argc, char *argv[])
                 throw std::runtime_error(std::string("Format not correct. Must be {\"backend_path\" : \"path/to/backend/json\"} or {\"fakeqmio_path\" : \"path/to/qmio/calibration/json\"}"));
             }
             
-        } else  if (argc < 3)
+        } else  if (argc < 4)
             SPDLOG_LOGGER_ERROR(logger, "Not a QPU configuration was given.");
             
         if (family_name == "default"){
@@ -53,13 +54,13 @@ int main(int argc, char *argv[])
 
         if(auto search = SIM_NAMES.find(simulator); search != SIM_NAMES.end()) {
             if (search->second == SimType::Aer) {
-                config::QPUConfig<SimType::Aer> qpu_config{qpu_config_json, info_path};
+                config::QPUConfig<SimType::Aer> qpu_config{mode, qpu_config_json, info_path};
                 QPU<SimType::Aer> qpu(qpu_config);
                 SPDLOG_LOGGER_DEBUG(logger, "Turning ON the QPUs with the AER simulator.");
                 qpu.turn_ON();
             } else if (search->second == SimType::Munich) {
                 SPDLOG_LOGGER_DEBUG(logger, "QPU_config: {}", qpu_config_json["noise"].dump(4));
-                config::QPUConfig<SimType::Munich> qpu_config{qpu_config_json, info_path};
+                config::QPUConfig<SimType::Munich> qpu_config{mode, qpu_config_json, info_path};
                 SPDLOG_LOGGER_DEBUG(logger, "QPU_config post qpu_config: {}", qpu_config.backend_config.noise_model.dump(4));
                 QPU<SimType::Munich> qpu(qpu_config);
                 SPDLOG_LOGGER_DEBUG(logger, "Turning ON the QPUs with the Munich simulator.");

--- a/src/comm/client.hpp
+++ b/src/comm/client.hpp
@@ -2,6 +2,7 @@
 
 #include <iostream>
 #include <fstream>
+#include <string_view>
 #include <memory>
 #include "comm_strat_def.h"
 #include "utils/constants.hpp"
@@ -53,13 +54,15 @@ public:
         }
     }
 
-    void connect(const std::string& task_id, const std::string_view& net = INFINIBAND) {
+    void connect(const std::string& task_id) {
         try {
             json server_ip_config_json = qpus_json.at(task_id).at("net");
             auto server_ip_config = server_ip_config_json.template get<NetConfig>();
             comm_strat->connect(server_ip_config);
         } catch (const json::out_of_range& e){
             SPDLOG_LOGGER_ERROR(logger, "No server has ID={}. Remember to set the servers with the command qraise.", task_id);
+        } catch (const std::exception& e) {
+            SPDLOG_LOGGER_ERROR(logger, "Error on when connecting the client");
         }
     }
 

--- a/src/config/net_config.hpp
+++ b/src/config/net_config.hpp
@@ -3,6 +3,7 @@
 #include <nlohmann/json.hpp>
 #include <iostream>
 #include <sys/types.h>
+#include <string_view>
 #include <ifaddrs.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
@@ -23,16 +24,17 @@ namespace config {
 
 class NetConfig {
 public:
+    std::string mode;
     std::string hostname;
     std::string nodename;
     std::unordered_map<std::string, std::string> IPs;
     std::string port;
 
     NetConfig();
-    NetConfig(const std::string& hostname, const std::string& nodename, std::unordered_map<std::string, std::string> IPs, std::string port);
+    NetConfig(const std::string& mode, const std::string& hostname, const std::string& nodename, std::unordered_map<std::string, std::string> IPs, std::string port);
     NetConfig(const json& server_info);
 
-    static NetConfig myNetConfig();
+    static NetConfig myNetConfig(const std::string& mode);
     std::string get_endpoint(const std::string_view& net = INFINIBAND) const;
 
     NetConfig& operator=(const NetConfig& other);
@@ -48,8 +50,9 @@ void from_json(const json& j, NetConfig& NetConfig);
 
 NetConfig::NetConfig() = default;
 
-NetConfig::NetConfig(const std::string& hostname, const std::string& nodename, std::unordered_map<std::string, std::string> IPs, std::string port)
-    : hostname{hostname},
+NetConfig::NetConfig(const std::string& mode, const std::string& hostname, const std::string& nodename, std::unordered_map<std::string, std::string> IPs, std::string port)
+    :   mode{mode},
+        hostname{hostname},
         nodename{nodename},
         IPs{IPs},
         port{port} 
@@ -60,9 +63,9 @@ NetConfig::NetConfig(const json& server_info)
     from_json(server_info, *this);
 }
 
-NetConfig NetConfig::myNetConfig() 
+NetConfig NetConfig::myNetConfig(const std::string& mode) 
 {
-    return NetConfig(get_hostname(), get_nodename(), get_IP_addresses(), get_port());
+    return NetConfig(mode, get_hostname(), get_nodename(), get_IP_addresses(), get_port());
 }
 
 std::string NetConfig::get_endpoint(const std::string_view& net) const 
@@ -73,6 +76,7 @@ std::string NetConfig::get_endpoint(const std::string_view& net) const
 NetConfig& NetConfig::operator=(const NetConfig& other) 
 {
     if (this != &other) {
+        mode = other.mode;
         hostname = other.hostname;
         nodename = other.nodename;
         IPs = other.IPs;
@@ -164,6 +168,7 @@ void to_json(json& j, const NetConfig& net_config)
     }
 
     j = {   
+            {"mode", net_config.mode},
             {"hostname", net_config.hostname}, 
             {"node_name", net_config.nodename},
             {"IPs", ips},
@@ -174,7 +179,7 @@ void to_json(json& j, const NetConfig& net_config)
 
 void from_json(const json& j, NetConfig& NetConfig) 
 {
-        
+    j.at("mode").get_to(NetConfig.mode);
     j.at("hostname").get_to(NetConfig.hostname);
     j.at("node_name").get_to(NetConfig.nodename);
     for (auto& netbind : j.at("IPs").items()) {
@@ -192,6 +197,7 @@ std::ostream& operator<<(std::ostream& os, const config::NetConfig& config) {
     }
     os << "\nPuerto: " << config.port
         << "\nNodename: " << config.nodename 
-       << "\nHostname: " << config.hostname << "\n\n";
+       << "\nHostname: " << config.hostname 
+       << "\nMode: " << config.mode << "\n\n";
     return os;
 }

--- a/src/config/qpu_config.hpp
+++ b/src/config/qpu_config.hpp
@@ -12,13 +12,14 @@ namespace config {
 template <SimType sim_type = SimType::Aer>
 class QPUConfig {
 public:
+    std::string mode;
     std::string family_name;
     std::string slurm_job_id;
     BackendConfig<sim_type> backend_config;
     NetConfig net_config;
     std::string filepath;
 
-    QPUConfig(const json& config, const std::string& filepath) :
+    QPUConfig(const std::string& mode, const json& config, const std::string& filepath) :
         filepath{filepath}, family_name(config.at("family_name")), slurm_job_id(config.at("slurm_job_id"))
     {
         if (config.contains("backend"))
@@ -31,7 +32,7 @@ public:
         if (config.contains("net"))
             this->net_config = NetConfig(config.at("net"));
         else {
-            this->net_config = NetConfig::myNetConfig();
+            this->net_config = NetConfig::myNetConfig(mode);
         }
     }
 
@@ -50,12 +51,14 @@ public:
 template <SimType sim_type>
 void to_json(json& j, const QPUConfig<sim_type>& qpu_config)
 {
+    std::string mode = qpu_config.mode;
     std::string family_name = qpu_config.family_name;
     std::string slurm_job_id = qpu_config.slurm_job_id;
     json net = qpu_config.net_config;
     json backend = qpu_config.backend_config;
 
     j = {   
+            {"mode", mode},
             {"family_name", family_name},
             {"slurm_job_id", slurm_job_id},
             {"net", net}, 
@@ -66,6 +69,7 @@ void to_json(json& j, const QPUConfig<sim_type>& qpu_config)
 template <SimType sim_type>
 void from_json(const json& j, QPUConfig<sim_type>& qpu_config) 
 {
+    qpu_config.mode = j.at("mode");
     qpu_config.family_name = j.at("family_name");
     qpu_config.slurm_job_id = j.at("slurm_job_id");
     qpu_config.net_config = j.at("net").template get<NetConfig>();

--- a/src/utils/constants.hpp
+++ b/src/utils/constants.hpp
@@ -10,6 +10,7 @@ using json = nlohmann::json;
 constexpr std::string_view INFINIBAND = "ib0";
 constexpr std::string_view VLAN120 = "VLAN120";
 constexpr std::string_view VLAN117 = "VLAN117";
+constexpr std::string_view LOCAL = "lo";
 
 
 enum GATES {


### PR DESCRIPTION
New `qraise` argument: `--mode`. It admits two possibilites: _hpc_ or _cloud_. By default is set to _hpc_ so that the users can connect only to the QPUs deployed on their current node. To do that, when _hpc_ is selected, the QPU server is listening on the localhost of the node.