### PR TITLE
ZMQ by default in classical communications

### DIFF
--- a/examples/example_cunqasimulator_distributed.py
+++ b/examples/example_cunqasimulator_distributed.py
@@ -18,7 +18,7 @@ qpu2 = qpus[2]
 
 d_qc_0_zmq = {
     "instructions": [
-
+        
     {
         "name":"h",
         "qubits":[0,-1,-1],

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -28,8 +28,8 @@ elseif(USE_QPU_ZMQ)
     set(QPU_COMM ZMQ)
     add_definitions(-DQPU_ZMQ)
 else()
-    set(QPU_COMM MPI)
-    add_definitions(-DQPU_MPI)
+    set(QPU_COMM ZMQ)
+    add_definitions(-DQPU_ZMQ)
 endif()
 
 


### PR DESCRIPTION
When building, the communication library is ZMQ by default. 