### PR TITLE
Communications arguments are now FLAGs

### DIFF
--- a/src/cli/qraise.cpp
+++ b/src/cli/qraise.cpp
@@ -133,32 +133,28 @@ int main(int argc, char* argv[])
         SPDLOG_LOGGER_ERROR(logger, "There are QPUs with the same family name as the provided: {}.", family_name);
         std::system("rm qraise_sbatch_tmp.sbatch");
         return 0;
-    } else if ( (args.comm.value() != "no_comm") && (args.comm.value() != "class_comm") && (args.comm.value() != "quantum_comm")) { //Check if the communication argument is correct
-        SPDLOG_LOGGER_ERROR(logger, "--comm only admits \"no_comm\", \"class_comm\" or \"quantum_comm\" as valid arguments");
-        std::system("rm qraise_sbatch_tmp.sbatch");
-        return 0;
     }
-    
+
     if (args.fakeqmio.has_value()) {
         SPDLOG_LOGGER_DEBUG(logger, "Fakeqmio provided as a FLAG");
         run_command = get_fakeqmio_run_command(args);
     } else {
-        if (args.comm.value() == "no_comm") {
-            SPDLOG_LOGGER_DEBUG(logger, "No communications");
-            run_command = get_no_comm_run_command(args);
-            if (run_command == "0") {
-                return 0;
-            }
-        } else if (args.comm.value() == "class_comm") {
+        if (args.classical_comm) {
             SPDLOG_LOGGER_DEBUG(logger, "Classical communications");
             run_command = get_class_comm_run_command(args);
             if (run_command == "0") {
                 return 0;
             }
-        } else { //Quantum Communication
+        } else if (args.quantum_comm) {
             SPDLOG_LOGGER_ERROR(logger, "Quantum communications are not implemented yet");
             std::system("rm qraise_sbatch_tmp.sbatch");
             return 0;
+        } else {
+            SPDLOG_LOGGER_DEBUG(logger, "No communications");
+            run_command = get_no_comm_run_command(args);
+            if (run_command == "0") {
+                return 0;
+            }
         }
     }
 

--- a/src/utils/qraise/args_qraise.hpp
+++ b/src/utils/qraise/args_qraise.hpp
@@ -22,7 +22,8 @@ struct MyArgs : public argparse::Args
     std::optional<std::string>& fakeqmio = kwarg("fq,fakeqmio", "Raise FakeQmio backend from calibration file", /*implicit*/"last_calibrations");
     std::string& family_name             = kwarg("fam,family_name", "Name that identifies which QPUs were raised together").set_default("default");
     std::string& mode                    = kwarg("mode", "Infraestructure mode: HPC or CLOUD").set_default("hpc");
-    std::optional<std::string>& comm     = kwarg("comm", "Raise QPUs with MPI communications").set_default("no_comm");
+    bool& classical_comm                 = flag("classical_comm", "Enable classical communications.");
+    bool& quantum_comm                   = flag("quantum_comm", "Enable quantum communications.");
 
     void welcome() {
         std::cout << "Welcome to qraise command, a command responsible for turn on the required QPUs.\n" << std::endl;


### PR DESCRIPTION
Communications arguments are now FLAGs instead of arguments with values: 

- For classical communications: `qraise --classical_comm`
- For quantum communications: `qraise --quantum_comm`
- By default: _no_communications_