### PR TITLE
Now to select cloud mode is it enough of doing --cloud on qraise

### DIFF
--- a/src/utils/qraise/args_qraise.hpp
+++ b/src/utils/qraise/args_qraise.hpp
@@ -19,9 +19,10 @@ struct MyArgs : public argparse::Args
     std::optional<int>& qpus_per_node    = kwarg("qpuN,qpus_per_node", "Number of qpus in each node.");
     std::optional<std::string>& backend  = kwarg("b,backend", "Path to the backend config file.");
     std::string& simulator               = kwarg("sim,simulator", "Simulator reponsible of running the simulations.").set_default("Aer");
-    std::optional<std::string>& fakeqmio = kwarg("fq,fakeqmio", "Raise FakeQmio backend from calibration file", /*implicit*/"last_calibrations");
-    std::string& family_name             = kwarg("fam,family_name", "Name that identifies which QPUs were raised together").set_default("default");
-    std::string& mode                    = kwarg("mode", "Infraestructure mode: HPC or CLOUD").set_default("hpc");
+    std::optional<std::string>& fakeqmio = kwarg("fq,fakeqmio", "Raise FakeQmio backend from calibration file.", /*implicit*/"last_calibrations");
+    std::string& family_name             = kwarg("fam,family_name", "Name that identifies which QPUs were raised together.").set_default("default");
+    //bool& hpc                          = flag("hpc", "Default HPC mode. The user can connect with the local node QPUs.");
+    bool& cloud                          = flag("cloud", "CLOUD mode. The user can connect with any deployed QPU.");
     bool& classical_comm                 = flag("classical_comm", "Enable classical communications.");
     bool& quantum_comm                   = flag("quantum_comm", "Enable quantum communications.");
 

--- a/src/utils/qraise/class_comm_conf_qraise.hpp
+++ b/src/utils/qraise/class_comm_conf_qraise.hpp
@@ -9,7 +9,7 @@
 #include "args_qraise.hpp"
 
 
-std::string get_class_comm_run_command(auto& args)
+std::string get_class_comm_run_command(auto& args, std::string& mode)
 {
     std::string run_command;
     std::string subcommand;
@@ -25,10 +25,10 @@ std::string get_class_comm_run_command(auto& args)
     if (args.backend.has_value()) {
         backend_path = std::any_cast<std::string>(args.backend.value());
         backend = R"({"backend_path":")" + backend_path + R"("})" ;
-        subcommand = std::any_cast<std::string>(args.mode) + " class_comm " + std::any_cast<std::string>(args.family_name) + " " + std::any_cast<std::string>(args.simulator) + " \'" + backend + "\'" "\n";
+        subcommand = mode + " class_comm " + std::any_cast<std::string>(args.family_name) + " " + std::any_cast<std::string>(args.simulator) + " \'" + backend + "\'" "\n";
         SPDLOG_LOGGER_DEBUG(logger, "Qraise with classical communications and personalized CunqaSimulator backend. \n");
     } else {
-        subcommand = std::any_cast<std::string>(args.mode) + " class_comm " + std::any_cast<std::string>(args.family_name) + " " + std::any_cast<std::string>(args.simulator) + "\n";
+        subcommand = mode + " class_comm " + std::any_cast<std::string>(args.family_name) + " " + std::any_cast<std::string>(args.simulator) + "\n";
         SPDLOG_LOGGER_DEBUG(logger, "Qraise with classical communications and default CunqaSimulator backend. \n");
     }
 

--- a/src/utils/qraise/fakeqmio_conf_qraise.hpp
+++ b/src/utils/qraise/fakeqmio_conf_qraise.hpp
@@ -8,7 +8,7 @@
 #include "logger/logger.hpp"
 #include "args_qraise.hpp"
 
-std::string get_fakeqmio_run_command(auto& args)
+std::string get_fakeqmio_run_command(auto& args, std::string& mode)
 {
     std::string run_command;
     std::string subcommand;
@@ -17,7 +17,7 @@ std::string get_fakeqmio_run_command(auto& args)
 
     backend_path = std::any_cast<std::string>(args.fakeqmio.value());
     backend = R"({"fakeqmio_path":")" + backend_path + R"("})" ;
-    subcommand = std::any_cast<std::string>(args.mode) + " no_comm " + std::any_cast<std::string>(args.family_name) + " Aer \'" + backend + "\'" + "\n";
+    subcommand = mode + " no_comm " + std::any_cast<std::string>(args.family_name) + " Aer \'" + backend + "\'" + "\n";
     run_command =  "srun --task-epilog=$BINARIES_DIR/epilog.sh setup_qpus $INFO_PATH " + subcommand;
     SPDLOG_LOGGER_DEBUG(logger, "Qraise FakeQmio. \n");
     SPDLOG_LOGGER_DEBUG(logger, "Run command: {}", run_command);

--- a/src/utils/qraise/no_comm_conf_qraise.hpp
+++ b/src/utils/qraise/no_comm_conf_qraise.hpp
@@ -8,7 +8,7 @@
 #include "logger/logger.hpp"
 #include "args_qraise.hpp"
 
-std::string get_no_comm_run_command(auto& args)
+std::string get_no_comm_run_command(auto& args, std::string& mode)
 {
     std::string run_command;
     std::string subcommand;
@@ -23,12 +23,12 @@ std::string get_no_comm_run_command(auto& args)
         } else {
             backend_path = std::any_cast<std::string>(args.backend.value());
             backend = R"({"backend_path":")" + backend_path + R"("})" ;
-            subcommand = std::any_cast<std::string>(args.mode) + " no_comm " + std::any_cast<std::string>(args.family_name) + " " + std::any_cast<std::string>(args.simulator) + " \'" + backend + "\'" "\n";
+            subcommand = mode + " no_comm " + std::any_cast<std::string>(args.family_name) + " " + std::any_cast<std::string>(args.simulator) + " \'" + backend + "\'" "\n";
             run_command = "srun --task-epilog=$BINARIES_DIR/epilog.sh setup_qpus $INFO_PATH " + subcommand;
             SPDLOG_LOGGER_DEBUG(logger, "Qraise with no communications and personalized backend. \n");
         }
     } else {
-        subcommand = std::any_cast<std::string>(args.mode) + " no_comm " + std::any_cast<std::string>(args.family_name) + " " + std::any_cast<std::string>(args.simulator) + "\n";
+        subcommand = mode + " no_comm " + std::any_cast<std::string>(args.family_name) + " " + std::any_cast<std::string>(args.simulator) + "\n";
         run_command = "srun --task-epilog=$BINARIES_DIR/epilog.sh setup_qpus $INFO_PATH " + subcommand;
         SPDLOG_LOGGER_DEBUG(logger, "Qraise default with no communications. \n");
     }


### PR DESCRIPTION
Now, to select the _CLOUD_ mode for the QPUs, it is enough to put the flag `--cloud` on the `qraise` command. By default, it is set the HPC mode.