### PR TITLE
Add check of the simulator name given to qraise by --simulator=

### DIFF
--- a/src/cli/qraise.cpp
+++ b/src/cli/qraise.cpp
@@ -81,14 +81,19 @@ int main(int argc, char* argv[])
         int cores_per_qpu = args.cores_per_qpu;
         sbatchFile << "#SBATCH --mem-per-cpu=" << mem_per_qpu/cores_per_qpu << "G\n";
     } else {
-        SPDLOG_LOGGER_DEBUG(logger, "Memory format is incorrect, must be: xG (where x is the number of Gigabytes).");
+        SPDLOG_LOGGER_ERROR(logger, "Memory format is incorrect, must be: xG (where x is the number of Gigabytes).");
         return -1;
     }
 
     if (check_time_format(args.time))
         sbatchFile << "#SBATCH --time=" << args.time << "\n";
     else {
-        SPDLOG_LOGGER_DEBUG(logger, "Time format is incorrect, must be: xx:xx:xx.");
+        SPDLOG_LOGGER_ERROR(logger, "Time format is incorrect, must be: xx:xx:xx.");
+        return -1;
+    }
+
+    if (!check_simulator_name(args.simulator)){
+        SPDLOG_LOGGER_ERROR(logger, "Incorrect simulator name ({}).", args.simulator);
         return -1;
     }
 

--- a/src/utils/qraise/utils_qraise.hpp
+++ b/src/utils/qraise/utils_qraise.hpp
@@ -47,3 +47,11 @@ bool exists_family_name(std::string& family_name, std::string& info_path)
         return false;
     }
 }
+
+bool check_simulator_name(std::string& sim_name){
+    if (sim_name == "Cunqa" || sim_name == "Munich" || sim_name == "Aer") {  // Add new valid simulators to the check here
+        return true;
+    } else {
+        return false;
+    }
+}


### PR DESCRIPTION
wrote function that checks that the value of --simulator=value is a supported simulator (otherwise the command fails without error). I also checked that other incorrect flag values are handled by slurm, whereas wholly incorrect flags are handled by the parser.