### PR TITLE
send() and recv() methods for classical communications

### DIFF
--- a/cunqa/mappers.py
+++ b/cunqa/mappers.py
@@ -37,7 +37,7 @@ def run_distributed(circuits, qpus, **run_args):
     distributed_qjobs = []
     circuit_jsons = []
 
-    distr_gates = ["d_c_if_h", "d_c_if_x","d_c_if_y","d_c_if_z","d_c_if_rx","d_c_if_ry","d_c_if_rz","d_c_if_cx","d_c_if_cy","d_c_if_cz", "d_c_if_ecr"]
+    remote_controlled_gates = ["measure_and_send", "remote_c_if_h", "remote_c_if_x","remote_c_if_y","remote_c_if_z","remote_c_if_rx","remote_c_if_ry","remote_c_if_rz","remote_c_if_cx","remote_c_if_cy","remote_c_if_cz", "remote_c_if_ecr"]
     correspondence = {}
 
     #Check wether the circuits are valid and extract jsons
@@ -81,8 +81,8 @@ def run_distributed(circuits, qpus, **run_args):
     #translate circuit ids in comm instruction to qpu endpoints
     for circuit in circuit_jsons:
         for instr in circuit["instructions"]:
-            if instr["name"] in distr_gates:
-                instr["qpus"] =  [correspondence[instr["circuits"][0]], correspondence[instr["circuits"][1]]]
+            if instr["name"] in remote_controlled_gates:
+                instr["qpus"] =  [correspondence[instr["circuits"][0]]]
                 instr.pop("circuits")
     
     warn = False

--- a/examples/backends/cunqa_backend.json
+++ b/examples/backends/cunqa_backend.json
@@ -10,7 +10,7 @@
         "max_shots": 1000000,
         "description": "CunqaSimulator",
         "basis_gates": [
-            "id", "h", "x", "y", "z", "cx", "cy", "cz", "ecr", "c_if_h", "c_if_x","c_if_y","c_if_z","c_if_rx","c_if_ry","c_if_rz","c_if_cx","c_if_cy","c_if_cz", "d_c_if_h", "d_c_if_x","d_c_if_y","d_c_if_z","d_c_if_rx","d_c_if_ry","d_c_if_rz","d_c_if_cx","d_c_if_cy","d_c_if_cz"
+            "id", "h", "x", "y", "z", "cx", "cy", "cz", "ecr", "c_if_h", "c_if_x","c_if_y","c_if_z","c_if_rx","c_if_ry","c_if_rz","c_if_cx","c_if_cy","c_if_cz", "remote_c_if_h", "remote_c_if_x","remote_c_if_y","remote_c_if_z","remote_c_if_rx","remote_c_if_ry","remote_c_if_rz","remote_c_if_cx","remote_c_if_cy","remote_c_if_cz"
         ], 
         "custom_instructions": "",
         "gates": [],

--- a/examples/ccomm_examples/01-the_easy_one.py
+++ b/examples/ccomm_examples/01-the_easy_one.py
@@ -11,22 +11,22 @@ from cunqa.qjob import gather
 
 
 # Raise QPUs (allocates classical resources for the simulation job) and retrieve them using getQPUs
-""" family = qraise(2,"00:10:00", simulator="Cunqa", classical_comm=True, cloud = True)
-os.system('sleep 5')
-qpus_QPE  = getQPUs(family) """
+family = qraise(2,"00:10:00", simulator="Cunqa", classical_comm=True, cloud = True)
+os.system('sleep 10')
+qpus_QPE  = getQPUs(family)
 
-qpus_QPE = getQPUs(local=False)
+#qpus_QPE = getQPUs(local=False)
 
 ########## Circuits to run ##########
 ########## First circuit ############
-cc_1 =CunqaCircuit(1, 1, id="first")
+cc_1 = CunqaCircuit(1, 1, id="first")
 cc_1.h(0)
-cc_1.send_gate("x", param=None, control_qubit = 0, target_qubit = 0, target_circuit = "second")
+cc_1.measure_and_send(control_qubit = 0, target_circuit = "second")
 #cc_1.measure(0,0)
 
 ########## Second circuit ###########
-cc_2 =CunqaCircuit(1, 1, id="second")
-cc_2.recv_gate("x", param=None, control_qubit = 0, control_circuit = "first", target_qubit = 0)
+cc_2 = CunqaCircuit(1, 1, id="second")
+cc_2.remote_c_if("x", target_qubits = 0, param=None, control_circuit = "first")
 cc_2.measure(0,0)
 
 
@@ -42,3 +42,6 @@ counts_list = [result.get_counts() for result in gather(distr_jobs)]
 
 ########## Print the counts #######
 print(counts_list)
+
+########## Drop the deployed QPUs #
+qdrop(family)

--- a/examples/ccomm_examples/02-the_cyclic_one.py
+++ b/examples/ccomm_examples/02-the_cyclic_one.py
@@ -22,8 +22,8 @@ def cyclic_ccommunication(n):
     circuits["cc_0"]=CunqaCircuit(2,2, id= f"cc_0")
     circuits["cc_0"].h(1)
     circuits["cc_0"].cx(1,0)
-    circuits["cc_0"].send_gate("x", param=None, control_qubit = 1, target_qubit = 0, target_circuit = f"cc_{1}") 
-    circuits["cc_0"].recv_gate("x", param=None, control_qubit = 1, control_circuit = f"cc_{n-1}", target_qubit = 0)
+    circuits["cc_0"].measure_and_send(control_qubit = 1, target_circuit = f"cc_{1}") 
+    circuits["cc_0"].remote_c_if("x", target_qubits = 0, param=None, control_circuit = f"cc_{n-1}")
 
     circuits[f"cc_0"].measure(0,0)
     circuits[f"cc_0"].measure(1,1)
@@ -31,12 +31,12 @@ def cyclic_ccommunication(n):
     for i in range(n-1):
         circuits[f"cc_{i+1}"]=CunqaCircuit(2,2, id= f"cc_{i+1}")
         
-        circuits[f"cc_{i+1}"].recv_gate("x", param=None, control_qubit = 1, control_circuit = f"cc_{i}", target_qubit = 0)
+        circuits[f"cc_{i+1}"].remote_c_if("x", target_qubits = 0, param=None, control_circuit = f"cc_{i}")
         circuits[f"cc_{i+1}"].h(1)
         circuits[f"cc_{i+1}"].cx(1,0)
 
         siguiente = mod(i+2,n)
-        circuits[f"cc_{i+1}"].send_gate("x", param=None, control_qubit = 1, target_qubit = 0, target_circuit = f"cc_{siguiente}") 
+        circuits[f"cc_{i+1}"].measure_and_send(control_qubit = 1, target_circuit = f"cc_{siguiente}") 
 
         circuits[f"cc_{i+1}"].measure(0,0)
         circuits[f"cc_{i+1}"].measure(1,1)
@@ -48,4 +48,4 @@ def cyclic_ccommunication(n):
     qdrop(family)
     return counts_list
 
-print(cyclic_ccommunication(25))
+print(cyclic_ccommunication(5))

--- a/examples/ccomm_examples/03-the_better_cyclic_one.py
+++ b/examples/ccomm_examples/03-the_better_cyclic_one.py
@@ -29,39 +29,39 @@ def cyclic_ccommunication(n):
     circuits["cc_0"]=CunqaCircuit(1,1, id= f"cc_0")
     circuits["cc_0"].h(0)
     circuits["cc_0"].rz(np.pi/6, 0)
-    circuits["cc_0"].send_gate("x", param=None, control_qubit = 0, target_qubit = 0, target_circuit = f"cc_{1}") 
-    circuits["cc_0"].send_gate("rx", param=np.pi/5, control_qubit = 0, target_qubit = 0, target_circuit = f"cc_{2}")
-    circuits["cc_0"].send_gate("ry", param=np.pi/3, control_qubit = 0, target_qubit = 0, target_circuit = f"cc_{3}")
+    circuits["cc_0"].measure_and_send(control_qubit = 0, target_circuit = f"cc_{1}") 
+    circuits["cc_0"].measure_and_send(control_qubit = 0, target_circuit = f"cc_{2}")
+    circuits["cc_0"].measure_and_send(control_qubit = 0, target_circuit = f"cc_{3}")
 
-    circuits["cc_0"].recv_gate("x", param=None, control_qubit = 0, control_circuit = f"cc_{n-1}", target_qubit = 0)
+    circuits["cc_0"].remote_c_if("x", target_qubits = 0, param=None, control_circuit = f"cc_{n-1}")
 
     circuits[f"cc_0"].measure(0,0)
     
     # For loop that creates the rest of the circuits and executes the communication instructions
     for i in range(n-1):
         circuits[f"cc_{i+1}"]=CunqaCircuit(1,1, id= f"cc_{i+1}")
-        circuits[f"cc_{i+1}"].recv_gate("x", param=None, control_qubit = 0, control_circuit = f"cc_{i}", target_qubit = 0)
+        circuits[f"cc_{i+1}"].remote_c_if("x", target_qubits = 0, param=None, control_circuit = f"cc_{i}")
         back_2 = mod(i-1,n)
         back_3 = mod(i-2,n)
         if i > 1:
-            circuits[f"cc_{i+1}"].recv_gate("rx", param=np.pi/5, control_qubit = 0, control_circuit = f"cc_{back_2}", target_qubit = 0)
+            circuits[f"cc_{i+1}"].remote_c_if("rx", target_qubits = 0, param=np.pi/5, control_circuit = f"cc_{back_2}")
 
         circuits[f"cc_{i+1}"].h(0)
 
         if i > 2:
-            circuits[f"cc_{i+1}"].recv_gate("ry", param=np.pi/3, control_qubit = 0, control_circuit = f"cc_{back_3}", target_qubit = 0)
+            circuits[f"cc_{i+1}"].remote_c_if("ry", target_qubits = 0, param=np.pi/3, control_circuit = f"cc_{back_3}")
         
         ############# NOW WE SEND ##################
 
         next = mod(i+2,n)
         next_2 = mod(i+3,n)
         next_3 = mod(i+4,n)
-        circuits[f"cc_{i+1}"].send_gate("x", param=None, control_qubit = 0, target_qubit = 0, target_circuit = f"cc_{next}") 
+        circuits[f"cc_{i+1}"].measure_and_send(control_qubit = 0, target_circuit = f"cc_{next}") 
 
         if i < n-2:
-            circuits[f"cc_{i+1}"].send_gate("rx", param=np.pi/5, control_qubit = 0, target_qubit = 0, target_circuit = f"cc_{next_2}")
+            circuits[f"cc_{i+1}"].measure_and_send(control_qubit = 0, target_circuit = f"cc_{next_2}")
             if i < n-3:
-                circuits[f"cc_{i+1}"].send_gate("ry", param=np.pi/3, control_qubit = 0, target_qubit = 0, target_circuit = f"cc_{next_3}")
+                circuits[f"cc_{i+1}"].measure_and_send(control_qubit = 0, target_circuit = f"cc_{next_3}")
 
         circuits[f"cc_{i+1}"].measure(0,0)
         
@@ -73,4 +73,4 @@ def cyclic_ccommunication(n):
     qdrop(family)
     return counts_list
 
-print(cyclic_ccommunication(15))
+print(cyclic_ccommunication(5))

--- a/examples/ccomm_examples/04-distr_QPE.py
+++ b/examples/ccomm_examples/04-distr_QPE.py
@@ -44,7 +44,7 @@ def distr_rz2_QPE(angle, n_precision):
     circuits = {}
     for i in range(n_precision): 
         theta = angle*np.pi*2**(n_precision-i)
-        print(f"Theta: {theta}")
+        #print(f"Theta: {theta}")
 
         circuits[f"cc_{i}"] = CunqaCircuit(3,3, id= f"cc_{i}") #we set the same number of quantum and classical bits because Cunqasimulator requires all qubits to be measured for them to be represented on the counts
         circuits[f"cc_{i}"].h(0)
@@ -55,14 +55,14 @@ def distr_rz2_QPE(angle, n_precision):
         
 
         for j in range(i):
-            print(f"Recibimos de {j} en {i}.")
-            circuits[f"cc_{i}"].recv_gate("rz", -np.pi*2**(i-j-2), control_qubit = 0, control_circuit = f"cc_{j}", target_qubit = 0)
+            #print(f"Recibimos de {j} en {i}.")
+            circuits[f"cc_{i}"].remote_c_if("rz", target_qubits = 0, param = -np.pi*2**(i-j-2), control_circuit = f"cc_{j}")
 
         circuits[f"cc_{i}"].h(0)
 
         for k in range(n_precision-i-1):
-            print(f"Mandamos desde {i} a {i+1+k}.")
-            circuits[f"cc_{i}"].send_gate("rz", -np.pi*2**(-i+k-1), control_qubit = 0, target_qubit = 0, target_circuit = f"cc_{i+1+k}") 
+            #print(f"Mandamos desde {i} a {i+1+k}.")
+            circuits[f"cc_{i}"].measure_and_send(control_qubit = 0, target_circuit = f"cc_{i+1+k}") 
 
         circuits[f"cc_{i}"].measure(0,0)
         circuits[f"cc_{i}"].measure(1,1)
@@ -83,8 +83,8 @@ def distr_rz2_QPE(angle, n_precision):
         
         
 
-#distr_rz2_QPE(0.25, 8)
+distr_rz2_QPE(1/2**4, 8)
 
-distr_rz2_QPE(0.63, 10)
+#distr_rz2_QPE(0.63, 10)
 
 

--- a/examples/example_cunqasimulator_distributed.py
+++ b/examples/example_cunqasimulator_distributed.py
@@ -26,12 +26,12 @@ d_qc_0_zmq = {
         "qubits":[0],
     },
     {
-        "name":"d_c_if_x",
+        "name":"remote_c_if_x",
         "qubits":[0,0],
         "circuits":["carballido", "losada"]
     },
     {
-        "name":"d_c_if_x",
+        "name":"remote_c_if_x",
         "qubits":[0,0],
         "circuits":["carballido", "exposito"]
     },
@@ -62,7 +62,7 @@ d_qc_1_zmq = {
     "id": "losada",
     "instructions": [
     {
-        "name":"d_c_if_x",
+        "name":"remote_c_if_x",
         "qubits":[1,0,-1],
         "circuits":["carballido", "losada"]
     },
@@ -103,7 +103,7 @@ d_qc_2_zmq = {
         "qubits":[1],
     },
     {
-        "name":"d_c_if_x",
+        "name":"remote_c_if_x",
         "qubits":[0,0],
         "circuits":["carballido", "exposito"]
     },

--- a/src/classical_node/communication_component.hpp
+++ b/src/classical_node/communication_component.hpp
@@ -175,5 +175,5 @@ inline int CommunicationComponent<sim_type>::is_sender_or_receiver(std::array<st
         }
 
     return -1;
-
+        
 }

--- a/src/utils/constants.hpp
+++ b/src/utils/constants.hpp
@@ -78,17 +78,18 @@ namespace CUNQA {
     C_IF_CY,
     C_IF_CZ,
     C_IF_ECR,
-    D_C_IF_H,
-    D_C_IF_X,
-    D_C_IF_Y,
-    D_C_IF_Z,
-    D_C_IF_RX,
-    D_C_IF_RY,
-    D_C_IF_RZ,
-    D_C_IF_CX,
-    D_C_IF_CY,
-    D_C_IF_CZ,
-    D_C_IF_ECR,
+    MEASURE_AND_SEND,
+    REMOTE_C_IF_H,
+    REMOTE_C_IF_X,
+    REMOTE_C_IF_Y,
+    REMOTE_C_IF_Z,
+    REMOTE_C_IF_RX,
+    REMOTE_C_IF_RY,
+    REMOTE_C_IF_RZ,
+    REMOTE_C_IF_CX,
+    REMOTE_C_IF_CY,
+    REMOTE_C_IF_CZ,
+    REMOTE_C_IF_ECR,
 };
 
 std::unordered_map<std::string, int> INSTRUCTIONS_MAP = {
@@ -133,18 +134,21 @@ std::unordered_map<std::string, int> INSTRUCTIONS_MAP = {
     {"c_if_cz", C_IF_CZ},
     {"c_if_ecr", C_IF_ECR},
 
-    //DISTRIBUTED GATES
-    {"d_c_if_h", D_C_IF_H},
-    {"d_c_if_x", D_C_IF_X},
-    {"d_c_if_y", D_C_IF_Y},
-    {"d_c_if_z", D_C_IF_Z},
-    {"d_c_if_rx", D_C_IF_RX},
-    {"d_c_if_ry", D_C_IF_RY},
-    {"d_c_if_rz", D_C_IF_RZ},
-    {"d_c_if_cx", D_C_IF_CX},
-    {"d_c_if_cy", D_C_IF_CY},
-    {"d_c_if_cz", D_C_IF_CZ},
-    {"d_c_if_ecr", D_C_IF_ECR},
+    // SEND CLASSICAL QUBIT
+    {"measure_and_send", MEASURE_AND_SEND},
+
+    // REMOTE CONTROLLED GATES
+    {"remote_c_if_h", REMOTE_C_IF_H},
+    {"remote_c_if_x", REMOTE_C_IF_X},
+    {"remote_c_if_y", REMOTE_C_IF_Y},
+    {"remote_c_if_z", REMOTE_C_IF_Z},
+    {"remote_c_if_rx", REMOTE_C_IF_RX},
+    {"remote_c_if_ry", REMOTE_C_IF_RY},
+    {"remote_c_if_rz", REMOTE_C_IF_RZ},
+    {"remote_c_if_cx", REMOTE_C_IF_CX},
+    {"remote_c_if_cy", REMOTE_C_IF_CY},
+    {"remote_c_if_cz", REMOTE_C_IF_CZ},
+    {"remote_c_if_ecr", REMOTE_C_IF_ECR},
 };
 
 std::unordered_map<int, std::string> INVERTED_GATE_NAMES = {
@@ -176,22 +180,22 @@ const std::vector<std::string> BASIS_GATES = {
             "cswap"};
 
   const std::vector<std::string> BASIS_AND_DISTRIBUTED_GATES = {
-    "unitary", "id", "h", "x", "y", "z", "rx", "ry", "rz", "cx", "cy", "cz", "crx", "cry", "crz", "ecr", "c_if_h", "c_if_x","c_if_y","c_if_z","c_if_rx","c_if_ry","c_if_rz","c_if_cx","c_if_cy","c_if_cz", "d_c_if_h", "d_c_if_x","d_c_if_y","d_c_if_z","d_c_if_rx","d_c_if_ry","d_c_if_rz","d_c_if_cx","d_c_if_cy","d_c_if_cz", "d_c_if_ecr"
+    "unitary", "id", "h", "x", "y", "z", "rx", "ry", "rz", "cx", "cy", "cz", "crx", "cry", "crz", "ecr", "c_if_h", "c_if_x","c_if_y","c_if_z","c_if_rx","c_if_ry","c_if_rz","c_if_cx","c_if_cy","c_if_cz", "measure_and_send", "remote_c_if_h", "remote_c_if_x","remote_c_if_y","remote_c_if_z","remote_c_if_rx","remote_c_if_ry","remote_c_if_rz","remote_c_if_cx","remote_c_if_cy","remote_c_if_cz", "remote_c_if_ecr"
   };
 
-  std::unordered_map<std::string, std::string> CORRESPONDENCE_D_GATE_MAP = {
-    {"d_c_if_unitary", "unitary"},
-    {"d_c_if_h", "h"},
-    {"d_c_if_x", "x"},
-    {"d_c_if_y", "y"},
-    {"d_c_if_z", "z"},
-    {"d_c_if_rx", "rx"},
-    {"d_c_if_ry", "ry"},
-    {"d_c_if_rz", "rz"},
-    {"d_c_if_cx", "cx"},
-    {"d_c_if_cy", "cy"},
-    {"d_c_if_cz", "cz"},
-    {"d_c_if_ecr", "ecr"},
+  std::unordered_map<std::string, std::string> CORRESPONDENCE_REMOTE_GATE_MAP = {
+    {"remote_c_if_unitary", "unitary"},
+    {"remote_c_if_h", "h"},
+    {"remote_c_if_x", "x"},
+    {"remote_c_if_y", "y"},
+    {"remote_c_if_z", "z"},
+    {"remote_c_if_rx", "rx"},
+    {"remote_c_if_ry", "ry"},
+    {"remote_c_if_rz", "rz"},
+    {"remote_c_if_cx", "cx"},
+    {"remote_c_if_cy", "cy"},
+    {"remote_c_if_cz", "cz"},
+    {"remote_c_if_ecr", "ecr"},
   };
 
 } //End namespace CUNQA


### PR DESCRIPTION
**Python**
- `def send_gate(self, gate, param, control_qubit = None, target_qubit = None, target_circuit = None):` -> `def measure_and_send(self, control_qubit = None, target_circuit = None):`
- `def recv_gate(self, gate, param, control_qubit = None, control_circuit = None, target_qubit = None):` -> `def remote_c_if(self, gate, target_qubits, param, control_circuit = None):`
- The gates names _d_c_if_[]_ change to _remote_c_if_[]_
- Updated the examples with classical communications to work with above new methods.

**C++**
- In _classical_node.hpp_: changed the beahaviour of` REMOTE_C_IF_[]` and added the new case `MEASURE_AND_SEND`
