### PR TITLE
Better management of communication endpoints

### DIFF
--- a/cunqa/mappers.py
+++ b/cunqa/mappers.py
@@ -71,7 +71,7 @@ def run_distributed(circuits: "list[Union[dict, 'CunqaCircuit']]", qpus: "list['
         if len(circuit_jsons) < len(qpus):
             logger.warning("More QPUs provided than the number of circuits. Last QPUs will remain unused.")
         for circuit, qpu in zip(circuit_jsons, qpus):
-            correspondence[circuit["id"]] = qpu._comm_endpoint
+            correspondence[circuit["id"]] = qpu._id
         
 
     #Check wether the QPUs are valid

--- a/cunqa/qpu.py
+++ b/cunqa/qpu.py
@@ -37,10 +37,9 @@ class QPU:
     _backend: 'Backend' 
     _family: str
     _endpoint: "tuple[str, int]" 
-    _comm_endpoint: str 
     _connected: bool 
     
-    def __init__(self, id: int, qclient: 'QClient', backend: Backend, family: str, endpoint: "tuple[str, int]", comm_endpoint: str):
+    def __init__(self, id: int, qclient: 'QClient', backend: Backend, family: str, endpoint: "tuple[str, int]"):
         """
         Initializes the QPU class.
 
@@ -61,7 +60,6 @@ class QPU:
         self._backend = backend
         self._family = family
         self._endpoint = endpoint
-        self._comm_endpoint = comm_endpoint
         self._connected = False
         
         logger.debug(f"Object for QPU {id} created correctly.")

--- a/cunqa/qutils.py
+++ b/cunqa/qutils.py
@@ -285,13 +285,10 @@ def getQPUs(local: bool = True, family: Optional[str] = None) -> "list['QPU']":
     
     # create QPU objects from the dictionary information + return them on a list
     qpus = []
-    i = 0
-    for _, info in targets.items():
+    for id, info in targets.items():
         client = QClient()
         endpoint = (info["net"]["ip"], info["net"]["port"])
-        comm_endpoint = info["communications_endpoint"]
-        qpus.append(QPU(id = i, qclient = client, backend = Backend(info['backend']), family = info["family"], endpoint = endpoint, comm_endpoint = comm_endpoint))
-        i+=1
+        qpus.append(QPU(id = id, qclient = client, backend = Backend(info['backend']), family = info["family"], endpoint = endpoint))
     if len(qpus) != 0:
         logger.debug(f"{len(qpus)} QPU objects were created.")
         return qpus

--- a/src/backends/backend.hpp
+++ b/src/backends/backend.hpp
@@ -18,7 +18,6 @@ public:
     virtual ~Backend() = default;
     virtual inline JSON execute(const QuantumTask& quantum_task) const = 0;
     virtual JSON to_json() const = 0;
-    virtual std::string get_communication_endpoint() = 0;
 };
 
 } // End of sim namespace

--- a/src/backends/classical_comm_backend.hpp
+++ b/src/backends/classical_comm_backend.hpp
@@ -82,12 +82,6 @@ public:
         return config_json;
     }
 
-    std::string get_communication_endpoint() override
-    {
-        std::string endpoint = this->simulator_->get_communication_endpoint_();
-        return endpoint;
-    }
-
 private:
     std::unique_ptr<SimulatorStrategy<ClassicalCommBackend>> simulator_;
 };

--- a/src/backends/simple_backend.hpp
+++ b/src/backends/simple_backend.hpp
@@ -82,12 +82,6 @@ public:
         return config_json;
     }
 
-    std::string get_communication_endpoint() override
-    {
-        std::string endpoint = this->simulator_->get_communication_endpoint_();
-        return endpoint;
-    }
-
 private:
     std::unique_ptr<SimulatorStrategy<SimpleBackend>> simulator_;
 };

--- a/src/backends/simulators/AER/aer_classical_comm_simulator.hpp
+++ b/src/backends/simulators/AER/aer_classical_comm_simulator.hpp
@@ -11,7 +11,7 @@ namespace sim {
 
 class AerCCSimulator final : public SimulatorStrategy<ClassicalCommBackend> {
 public:
-    AerCCSimulator(): classical_channel(std::make_unique<comm::ClassicalChannel>()) {};
+    AerCCSimulator();
     ~AerCCSimulator() = default;
 
     inline std::string get_name() const override {return "AerSimulator";}
@@ -19,11 +19,7 @@ public:
     
 
 private:
-    JSON distributed_execution_(const ClassicalCommBackend& backend, const QuantumTask& quantum_task);
-    std::string get_communication_endpoint_() override;
-
     std::unique_ptr<comm::ClassicalChannel> classical_channel;
-    
 };
 
 

--- a/src/backends/simulators/AER/aer_simulator.cpp
+++ b/src/backends/simulators/AER/aer_simulator.cpp
@@ -18,11 +18,25 @@
 #include "utils/constants.hpp"
 #include "logger.hpp"
 
+using namespace std::string_literals;
+namespace {
+    const auto store = getenv("STORE");
+    const std::string filepath = store + "/.cunqa/communications.json"s;
+}
 
 using namespace AER;
 
 namespace cunqa {
 namespace sim {
+
+AerCCSimulator::AerCCSimulator() : classical_channel(std::make_unique<comm::ClassicalChannel>())
+{
+    JSON communications_endpoint = 
+    {
+        {"communications_endpoint", classical_channel->endpoint}
+    };
+    write_on_file(communications_endpoint, filepath);
+};
 
 // Free function used in both simple and distributed case
 template <class BackendType>
@@ -412,12 +426,6 @@ JSON AerCCSimulator::execute(const ClassicalCommBackend& backend, const QuantumT
     } else {
         return dynamic_execution_<ClassicalCommBackend>(backend, quantum_task, this->classical_channel.get());
     } 
-}
-
-std::string AerCCSimulator::get_communication_endpoint_()
-{
-    std::string endpoint = this->classical_channel->endpoint;
-    return endpoint;
 }
 
 

--- a/src/backends/simulators/CUNQA/cunqa_classical_comm_simulator.cpp
+++ b/src/backends/simulators/CUNQA/cunqa_classical_comm_simulator.cpp
@@ -1,10 +1,24 @@
 #include "cunqa_classical_comm_simulator.hpp"
 #include "cunqa_executors.hpp"
 
-#include "utils/json.hpp"
+
+using namespace std::string_literals;
+namespace {
+    const auto store = getenv("STORE");
+    const std::string filepath = store + "/.cunqa/communications.json"s;
+}
 
 namespace cunqa {
 namespace sim {
+
+CunqaCCSimulator::CunqaCCSimulator() : classical_channel(std::make_unique<comm::ClassicalChannel>())
+{
+    JSON communications_endpoint = 
+    {
+        {"communications_endpoint", classical_channel->endpoint}
+    };
+    write_on_file(communications_endpoint, filepath);
+}
 
 JSON CunqaCCSimulator::execute(const ClassicalCommBackend& backend, const QuantumTask& quantum_task)
 {
@@ -12,11 +26,6 @@ JSON CunqaCCSimulator::execute(const ClassicalCommBackend& backend, const Quantu
     return cunqa_execution_<ClassicalCommBackend>(backend, quantum_task, this->classical_channel.get());
 }
 
-std::string CunqaCCSimulator::get_communication_endpoint_()
-{
-    std::string endpoint = this->classical_channel->endpoint;
-    return endpoint;
-}
 
 } // End namespace sim
 } // End namespace cunqa

--- a/src/backends/simulators/CUNQA/cunqa_classical_comm_simulator.hpp
+++ b/src/backends/simulators/CUNQA/cunqa_classical_comm_simulator.hpp
@@ -13,16 +13,13 @@ namespace sim {
 class CunqaCCSimulator final : public SimulatorStrategy<ClassicalCommBackend>
 {
 public:
-    CunqaCCSimulator() : classical_channel(std::make_unique<comm::ClassicalChannel>())
-    {}
+    CunqaCCSimulator();
     ~CunqaCCSimulator() = default;
 
     inline std::string get_name() const override {return "CunqaSimulator";}
     JSON execute(const ClassicalCommBackend& backend, const QuantumTask& quantumtask) override; 
 
 private:
-    std::string get_communication_endpoint_() override;
-
     std::unique_ptr<comm::ClassicalChannel> classical_channel;
 };
 

--- a/src/backends/simulators/Munich/munich_classical_comm_simulator.cpp
+++ b/src/backends/simulators/Munich/munich_classical_comm_simulator.cpp
@@ -7,11 +7,25 @@
 
 #include "quantum_task.hpp"
 #include "backends/simulators/simulator_strategy.hpp"
-#include "utils/json.hpp"
 
+
+using namespace std::string_literals;
+namespace {
+    const auto store = getenv("STORE");
+    const std::string filepath = store + "/.cunqa/communications.json"s;
+}
 
 namespace cunqa {
 namespace sim {
+
+MunichCCSimulator::MunichCCSimulator() : classical_channel(std::make_unique<comm::ClassicalChannel>()) 
+{
+    JSON communications_endpoint = 
+    {
+        {"communications_endpoint", classical_channel->endpoint}
+    };
+    write_on_file(communications_endpoint, filepath);
+}
 
 JSON MunichCCSimulator::execute(const ClassicalCommBackend& backend, const QuantumTask& quantum_task)
 {
@@ -21,12 +35,6 @@ JSON MunichCCSimulator::execute(const ClassicalCommBackend& backend, const Quant
     } else {
         return dynamic_execution_<ClassicalCommBackend>(backend, quantum_task, this->classical_channel.get());
     }   
-}
-
-std::string MunichCCSimulator::get_communication_endpoint_()
-{
-    std::string endpoint = this->classical_channel->endpoint;
-    return endpoint;
 }
 
 } // End namespace sim

--- a/src/backends/simulators/Munich/munich_classical_comm_simulator.hpp
+++ b/src/backends/simulators/Munich/munich_classical_comm_simulator.hpp
@@ -21,7 +21,7 @@ namespace sim {
 
 class MunichCCSimulator final : public SimulatorStrategy<ClassicalCommBackend> {
 public:
-    MunichCCSimulator(): classical_channel(std::make_unique<comm::ClassicalChannel>()) {};
+    MunichCCSimulator();
     ~MunichCCSimulator() = default;
 
     inline std::string get_name() const override {return "MunichSimulator";}
@@ -29,7 +29,6 @@ public:
     
 
 private:
-    std::string get_communication_endpoint_() override;
 
     std::unique_ptr<comm::ClassicalChannel> classical_channel;
     

--- a/src/backends/simulators/simulator_strategy.hpp
+++ b/src/backends/simulators/simulator_strategy.hpp
@@ -14,7 +14,6 @@ public:
 
     virtual inline std::string get_name() const = 0;
     virtual JSON execute(const T& backend, const QuantumTask& circuit) = 0;
-    virtual std::string get_communication_endpoint_() {return "";}
 };
 
 } // End of sim namespace

--- a/src/classical_channel/classical_channel.hpp
+++ b/src/classical_channel/classical_channel.hpp
@@ -13,7 +13,7 @@ public:
     ClassicalChannel();
     ~ClassicalChannel();
 
-    void set_classical_connections(std::vector<std::string>& endpoints);
+    void set_classical_connections(std::vector<std::string>& qpus_id);
     void send_measure(int& measurement, std::string& target);
     int recv_measure(std::string& origin);
     

--- a/src/classical_channel/classical_channel_impl/mpi/mpi_classical_channel.cpp
+++ b/src/classical_channel/classical_channel_impl/mpi/mpi_classical_channel.cpp
@@ -54,7 +54,7 @@ int ClassicalChannel::recv_measure(std::string& origin)
     return pimpl_->recv(origin);
 }
 
-void ClassicalChannel::set_classical_connections(std::vector<std::string>& endpoints)
+void ClassicalChannel::set_classical_connections(std::vector<std::string>& qpus_id)
 {
     LOGGER_DEBUG("MPI does not need to set connections.");
 }

--- a/src/classical_channel/classical_channel_impl/zmq/zmq_classical_channel.cpp
+++ b/src/classical_channel/classical_channel_impl/zmq/zmq_classical_channel.cpp
@@ -107,10 +107,10 @@ int ClassicalChannel::recv_measure(std::string& origin)
     return pimpl_->recv(origin);
 }
 
-void ClassicalChannel::set_classical_connections(std::vector<std::string>& endpoints)
+void ClassicalChannel::set_classical_connections(std::vector<std::string>& qpus_id)
 {
     LOGGER_DEBUG("Setting connections on classical channel.");
-    pimpl_->set_connections(endpoints);
+    pimpl_->set_connections(qpus_id);
 }
 
 

--- a/src/cli/epilog.sh
+++ b/src/cli/epilog.sh
@@ -4,6 +4,10 @@ JOB_ID="${SLURM_JOB_ID}"
 
 flock $INFO_PATH -c "/mnt/netapp1/Optcesga_FT2_RHEL7/2020/gentoo/22072020/usr/bin/jq --arg job_id \"$SLURM_JOB_ID\" 'with_entries(select(.key | startswith(\$job_id) | not))' $INFO_PATH > tmp.json && mv tmp.json $INFO_PATH"
 
+if compgen -G "$STORE/.cunqa/communications.json" > /dev/null; then
+    flock $COMM_PATH -c "/mnt/netapp1/Optcesga_FT2_RHEL7/2020/gentoo/22072020/usr/bin/jq --arg job_id \"$SLURM_JOB_ID\" 'with_entries(select(.key | startswith(\$job_id) | not))' $COMM_PATH > tmp.json && mv tmp.json $COMM_PATH"
+fi
+
 if compgen -G "$STORE/.cunqa/tmp_fakeqmio_backend_$SLURM_JOB_ID.json" > /dev/null; then
     rm $STORE/.cunqa/tmp_fakeqmio_backend_$SLURM_JOB_ID.json
 fi

--- a/src/cli/qraise.cpp
+++ b/src/cli/qraise.cpp
@@ -31,6 +31,7 @@ int main(int argc, char* argv[])
 
     const char* store = std::getenv("STORE");
     std::string info_path = std::string(store) + "/.cunqa/qpus.json";
+    std::string comm_path = std::string(store) + "/.cunqa/communications.json";
 
     std::ofstream sbatchFile("qraise_sbatch_tmp.sbatch");
     LOGGER_DEBUG("Temporal file qraise_sbatch_tmp.sbatch created.");
@@ -116,6 +117,7 @@ int main(int argc, char* argv[])
 
     sbatchFile << "BINARIES_DIR=" << std::getenv("STORE") << "/.cunqa\n";
     sbatchFile << "export INFO_PATH=" << info_path + "\n";
+    sbatchFile << "export COMM_PATH=" << comm_path + "\n";
 
     //Checking duplicate family name
     std::string family = std::any_cast<std::string>(args.family_name);

--- a/src/qpu.hpp
+++ b/src/qpu.hpp
@@ -35,14 +35,11 @@ private:
     friend void to_json(JSON& j, const QPU& obj) {
         JSON backend_json = obj.backend->to_json();
         JSON server_json = *(obj.server);
-        std::string communications_endpoint = obj.backend->get_communication_endpoint();
-        LOGGER_DEBUG("QPU communications endpoint: {}", communications_endpoint);
         j = {
             {"backend", backend_json},
             {"net", server_json},
             {"family", obj.family_},
-            {"slurm_job_id", std::getenv("SLURM_JOB_ID")},
-            {"communications_endpoint", communications_endpoint}
+            {"slurm_job_id", std::getenv("SLURM_JOB_ID")}
         };
     }
 };

--- a/src/quantum_task.cpp
+++ b/src/quantum_task.cpp
@@ -1,4 +1,11 @@
+#include <string>
+#include <vector>
+#include <fstream>
+#include <iostream>
+#include <cstdlib>
+
 #include "quantum_task.hpp"
+#include "utils/json.hpp"
 #include "utils/constants.hpp"
 
 #include "logger.hpp"
@@ -11,10 +18,42 @@ void QuantumTask::update_circuit(const std::string& quantum_task)
     std::vector<std::string> no_communications = {};
 
     if (quantum_task_json.contains("instructions") && quantum_task_json.contains("config")) {
-        circuit = quantum_task_json.at("instructions");
-        config = quantum_task_json.at("config");
+        circuit = quantum_task_json.at("instructions").get<std::vector<JSON>>();
+        config = quantum_task_json.at("config").get<JSON>();
         sending_to = (quantum_task_json.contains("sending_to") ? quantum_task_json.at("sending_to").get<std::vector<std::string>>() : no_communications);
         is_dynamic = ((quantum_task_json.contains("is_dynamic")) ? quantum_task_json.at("is_dynamic").get<bool>() : false);
+        is_distributed = ((quantum_task_json.contains("is_distributed")) ? quantum_task_json.at("is_distributed").get<bool>() : false);
+
+        LOGGER_DEBUG("After quantum task keys");
+
+        if (is_distributed) {
+            LOGGER_DEBUG("is_distributed");
+            const char* STORE = std::getenv("STORE");
+            std::string filepath = std::string(STORE) + "/.cunqa/communications.json";
+            std::ifstream communications_file(filepath); 
+            // TODO: Manage behaviour when file is not well opened
+
+            JSON communications;
+            communications_file >> communications;
+            LOGGER_DEBUG("qpus json well read");
+
+            for (auto& instruction : circuit) {
+                std::string name = instruction.at("name").get<std::string>();
+                if (instruction.contains("qpus")) {
+                    std::vector<std::string> qpuid = instruction.at("qpus").get<std::vector<std::string>>();  
+                    JSON qpu_communications = communications.at(qpuid[0]).get<JSON>();
+                    std::string communications_endpoint = qpu_communications.at("communications_endpoint").get<std::string>();
+                    instruction.at("qpus") = {communications_endpoint};
+                }
+            }
+            std::vector<std::string> aux_connects_with = sending_to;
+            int counter = 0;
+            for (auto& qpuid : aux_connects_with) {
+                JSON qpu = communications.at(qpuid).get<JSON>();
+                sending_to[counter] = qpu.at("communications_endpoint").get<std::string>();
+                counter++;
+            }
+        }
 
     } else if (quantum_task_json.contains("params")) {
         update_params_(quantum_task_json.at("params"));

--- a/src/quantum_task.hpp
+++ b/src/quantum_task.hpp
@@ -11,16 +11,16 @@ public:
     JSON circuit;
     JSON config;
     std::vector<std::string> sending_to;
-    bool is_dynamic;
+    bool is_dynamic = false; // C_IF gates
+    bool is_distributed = false; // Classical Communications
 
-    QuantumTask() : is_dynamic{false} {};
+    QuantumTask() = default;
 
-    QuantumTask(const JSON& circuit, const JSON& config): circuit(circuit), config(config) { };
+    QuantumTask(const JSON& circuit, const JSON& config): circuit(circuit), config(config) {};
 
     void update_circuit(const std::string& quantum_task);
 
 private:
-
     
     void update_params_(const std::vector<double> params);
 };


### PR DESCRIPTION
1. Now the circuits don't send the communication endpoints to the C++ part but the _qpu_id_.
2. The `update_circuit()` method of the class `QuantumTask` is now the resposible of translating the _qpu_id_ to the _communication_endpoint_
3. The classical _communications_endpoints_ are no longer written in _qpus.json_ but in a different file named _/.cunqa/communications.json_ 
4. The resposible of write on the _communications.json_ are the constructors of the CC-classes of each simulator: `AerCCSimulator`, `MunichCCSimulator` and `CunqaCCSimulator`
5. The _epilog.sh_ manages the clean of both _qpus.json_ and _communications.json_