### PR TITLE
Adaptations in CmakeLists to allow new compilation of CunqaSimulator

### DIFF
--- a/examples/python/example_qraise.py
+++ b/examples/python/example_qraise.py
@@ -8,7 +8,7 @@ from cunqa.qutils import getQPUs, qraise, qdrop
 from cunqa.circuit import CunqaCircuit
 
 # Raise QPUs (allocates classical resources for the simulation job) and retrieve them using getQPUs
-family = qraise(2, "00:10:00", simulator = "Munich", cloud = True)
+family = qraise(2, "00:10:00", simulator = "Cunqa", cloud = True)
 
 qpus  = getQPUs(local = False, family = family)
 

--- a/src/backends/simulators/CUNQA/CMakeLists.txt
+++ b/src/backends/simulators/CUNQA/CMakeLists.txt
@@ -3,14 +3,14 @@ add_library(cunqa_simple_simulator "${CMAKE_CURRENT_SOURCE_DIR}/cunqa_simple_sim
 target_include_directories(cunqa_simple_simulator PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/src"
                                                             "${CMAKE_SOURCE_DIR}/src/third-party/cunqasimulator/"
                                                             "${CMAKE_SOURCE_DIR}/src/classical_channel")
-target_link_libraries(cunqa_simple_simulator PUBLIC json logger_qpu classical_channel)
+target_link_libraries(cunqa_simple_simulator PUBLIC cunqasimulator json logger_qpu classical_channel)
 
 
 add_library(cunqa_cc_simulator "${CMAKE_CURRENT_SOURCE_DIR}/cunqa_cc_simulator.cpp")
 target_include_directories(cunqa_cc_simulator PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}"
                                                             "${CMAKE_SOURCE_DIR}/src/third-party/cunqasimulator/" 
                                                             "${CMAKE_SOURCE_DIR}/src/classical_channel")
-target_link_libraries(cunqa_cc_simulator PUBLIC json logger_qpu classical_channel)
+target_link_libraries(cunqa_cc_simulator PUBLIC cunqasimulator json logger_qpu classical_channel)
 
 
 

--- a/src/third-party/CMakeLists.txt
+++ b/src/third-party/CMakeLists.txt
@@ -33,11 +33,11 @@ FetchContent_Declare(
 FetchContent_MakeAvailable(zmq)
 
 
-#FetchContent_Declare(
-#  cunqasimulator
-#  SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/cunqasimulator
-#)
-#FetchContent_MakeAvailable(cunqasimulator)
+FetchContent_Declare(
+  cunqasimulator
+  SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/cunqasimulator
+)
+FetchContent_MakeAvailable(cunqasimulator)
 
 # TODO: Change this to non global
 set(ZMQ_BINARY_DIR "${zmq_BINARY_DIR}"


### PR DESCRIPTION
Adapatation of _CMakeListst_ files to allow the new compilation of _CunqaSimulator_. Remember that previously, _CunqaSimulator_ was an only-header library