### PR TITLE
fixed distr_QPE example

### DIFF
--- a/examples/ccomm_examples/05-ibm-cut-bell-pairs-telegate.py
+++ b/examples/ccomm_examples/05-ibm-cut-bell-pairs-telegate.py
@@ -26,7 +26,7 @@ def t_k(k):
 
 def how_big_a_combination(k):
     #print(f"For generating a {k}-Cut Bell Pair Factory one needs to specify {4**(k)-2**(k)+2**(2**k)-1} parameter sets.")
-    return 4**(k)-2**(k) + 2**(2**k)-1
+    return n_minus(k) + n_plus(k)
 
 
 # Raise QPUs (allocates classical resources for the simulation job) and retrieve them using getQPUs #
@@ -36,7 +36,7 @@ qpus_QPE  = getQPUs(local = False, family = family)
 # Params for the gates in the Cut Bell Pair Factory #
 with open(examples_path + "/ccomm_examples/two_qpd_bell_pairs_param_values.txt") as fin:
     params2 = [[float(val) for val in line.replace("\n","").split(" ")] for line in fin.readlines()]
-z = params2[0] # This one doesn't matter, it will be overwritten afterwards
+z = params2[0] # This one doesn't matter, it will be overwritten afterwards with upgrade_parameters
 
 ############ CIRCUIT 1 #########################
 Alice = CunqaCircuit(3,3, id="Alice")


### PR DESCRIPTION
Fixed issues with the distr_QPE algorithm. Once New Perspectives for CunqaCircuit is merged into classical comm the algorithm can be enhanced by allowing the user to pass a eigenvector and a diagonal gate for which we estimate the eigenvalue.