### PR TITLE
Mutes the missing GPU library warning

### DIFF
--- a/src/backends/simulators/Maestro/maestro_adapters/MaestroLib.hpp
+++ b/src/backends/simulators/Maestro/maestro_adapters/MaestroLib.hpp
@@ -23,7 +23,7 @@ public:
 	{
 		if (Utils::Library::Init(libName))
 		{
-			fGetMaestroObject = (void* (*)())GetFunction("GetMaestroObject");
+			fGetMaestroObject = (void* (*)())GetFunction("GetMaestroObjectWithMute");
 			CheckFunction((void*)fGetMaestroObject, __LINE__);
 			if (fGetMaestroObject)
 			{


### PR DESCRIPTION
This change will mute the missing GPU library warning. For debugging purposes, this can be reverted if needed.