### PR TITLE
Corrected several bugs in munich_simulator_adapter

### DIFF
--- a/src/backends/simulators/AER/aer_adapters/aer_simulator_adapter.cpp
+++ b/src/backends/simulators/AER/aer_adapters/aer_simulator_adapter.cpp
@@ -229,8 +229,7 @@ std::string execute_shot_(
         {
             // state->flush_ops();
             //------------- Generate Entanglement ---------------
-            state->apply_h(G.n_qubits - 2);
-            state->apply_mcx({G.n_qubits - 2, G.n_qubits - 1});
+            generate_entanglement_();
             //----------------------------------------------------
 
             // CX to the entangled pair
@@ -329,7 +328,6 @@ std::string execute_shot_(
             G.qc_meas[T.id].push(result);
 
             Ts[inst.at("qpus")[0]].blocked = false;
-            size_t erased_elements = G.qc_meas.erase(inst.at("qpus")[0]); 
             break;
         }
         default:

--- a/src/backends/simulators/CUNQA/cunqa_adapters/cunqa_simulator_adapter.cpp
+++ b/src/backends/simulators/CUNQA/cunqa_adapters/cunqa_simulator_adapter.cpp
@@ -182,8 +182,7 @@ std::string execute_shot_(
         case cunqa::constants::QSEND:
         {
             //------------- Generate Entanglement ---------------
-            executor.apply_gate("h", {G.n_qubits - 2});
-            executor.apply_gate("cx", {G.n_qubits - 2, G.n_qubits - 1});
+            generate_entanglement_();
             //----------------------------------------------------
 
             // CX to the entangled pair
@@ -290,7 +289,6 @@ std::string execute_shot_(
             G.qc_meas[T.id].push(result);
 
             Ts[inst.at("qpus")[0]].blocked = false;
-            size_t erased_elements = G.qc_meas.erase(inst.at("qpus")[0]); 
             break;
         }
         default:

--- a/src/backends/simulators/Maestro/maestro_adapters/maestro_simulator_adapter.cpp
+++ b/src/backends/simulators/Maestro/maestro_adapters/maestro_simulator_adapter.cpp
@@ -223,8 +223,7 @@ std::string execute_shot_(
         case cunqa::constants::QSEND:
         {
             //------------- Generate Entanglement ---------------
-            ApplyH(simulator, G.n_qubits - 2);
-			ApplyCX(simulator, G.n_qubits - 2, G.n_qubits - 1);
+            generate_entanglement_();
             //----------------------------------------------------
 
             // CX to the entangled pair
@@ -329,7 +328,6 @@ std::string execute_shot_(
             G.qc_meas[T.id].push(measurement_as_int);
 
             Ts[inst.at("qpus")[0]].blocked = false;
-            size_t erased_elements = G.qc_meas.erase(inst.at("qpus")[0]); 
             break;
         }
         default:

--- a/src/backends/simulators/Munich/munich_adapters/munich_simulator_adapter.hpp
+++ b/src/backends/simulators/Munich/munich_adapters/munich_simulator_adapter.hpp
@@ -22,6 +22,11 @@ public:
     inline void initializeSimulationAdapter(std::size_t nQubits) { initializeSimulation(nQubits); }
     inline void applyOperationToStateAdapter(std::unique_ptr<qc::Operation>&& op) { applyOperationToState(op); }
     inline char measureAdapter(dd::Qubit i) { return measure(i); }
+    inline void resetStateAdapter(const int n_qubits) 
+    { 
+        qc::Targets target_qubits(n_qubits); 
+        reset(new qc::NonUnitaryOperation(target_qubits));
+    }
 
     JSON simulate(const Backend* backend);
     JSON simulate(comm::ClassicalChannel* classical_channel = nullptr);

--- a/src/backends/simulators/Qulacs/qulacs_adapters/qulacs_simulator_adapter.cpp
+++ b/src/backends/simulators/Qulacs/qulacs_adapters/qulacs_simulator_adapter.cpp
@@ -296,8 +296,7 @@ std::string execute_shot_(
         case cunqa::constants::QSEND:
         {
             //------------- Generate Entanglement ---------------
-            gate::H(G.n_qubits - 2)->update_quantum_state(&state);
-            gate::CNOT(G.n_qubits - 2, G.n_qubits - 1)->update_quantum_state(&state);
+           generate_entanglement_();
             //----------------------------------------------------
 
             // CX to the entangled pair
@@ -395,7 +394,6 @@ std::string execute_shot_(
             G.qc_meas[T.id].push(result);
 
             Ts[inst.at("qpus")[0]].blocked = false;
-            size_t erased_elements = G.qc_meas.erase(inst.at("qpus")[0]); 
             break;
         }
         default:


### PR DESCRIPTION
There were several problems in _munich_simulator_adapter.cpp_:

1. The simulation was initiliazed at every shot
2. The state was not reset after every shot. To fix this I implemented a `resetStateAdapter `.
3. The controlled quantum operations (CX, CY, etc.) were bad implemented in the dynamic simulator. There was not chek if the controlled operation was distributed or not. 

Everything looks solved.