### PR TITLE
Add NetQMPI adapter layer to support CUNQA and NetQASM backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,48 @@ For a complete and exhaustive explanation and functionality showcase of CUNQA vi
     - [Install as Lmod module](#install-as-lmod-module)
   - [UNINSTALL](#uninstall)
   - [RUN YOUR FIRST DISTRIBUTED PROGRAM](#run-your-first-distributed-program)
+  - [NETQMPI ADAPTER (CUNQA + NETQASM)](#netqmpi-adapter-cunqa--netqasm)
     - [PYTHON-BASH](#python-bash)
     - [PYTHON-ONLY](#python-only)
   - [ACKNOWLEDGEMENTS](#acknowledgements)
+
+
+## NetQMPI adapter (CUNQA + NetQASM)
+
+This repository now includes a lightweight adapter layer for integrating NetQMPI-style communication with CUNQA and NetQASM as interchangeable backends.
+
+Main components are exposed in `cunqa.netqmpi_adapter`:
+
+- `BackendAdapter`: backend selector/factory (`"cunqa"` or `"netqasm"`).
+- `QMPIComm`: common communication facade (`MPI_Init`, `QMPI_Init`, `send`, `recv`, `barrier`, `finalize`).
+- `CUNQAComm` and `NetQASMComm`: backend wrappers around user-provided communication callables.
+
+Minimal usage example:
+
+```python
+from cunqa import BackendAdapter, QMPIComm
+
+def send_fn(payload, dst, tag):
+    ...
+
+def recv_fn(src, tag):
+    ...
+
+adapter = BackendAdapter.from_name(
+    "cunqa",
+    send_fn=send_fn,
+    recv_fn=recv_fn,
+)
+
+comm = QMPIComm(adapter)
+comm.MPI_Init()
+comm.QMPI_Init()
+comm.send({"x": 1}, dst=1, tag=0)
+msg = comm.recv(src=1, tag=0)
+comm.finalize()
+```
+
+This structure follows the adapter architecture where NetQMPI code targets a common communicator while backend-specific logic is delegated to CUNQA/NetQASM adapters.
 
 ## Install
 

--- a/cunqa/__init__.py
+++ b/cunqa/__init__.py
@@ -28,6 +28,7 @@ import importlib as _importlib
 _submodules = [
     "circuit",
     "qiskit_deps",
+    "netqmpi_adapter",
     "qjob",
     "result",
     "qpu",
@@ -38,7 +39,11 @@ _lazy_symbols = {
     "get_QPUs": ("cunqa.qpu", "get_QPUs"),
     "qraise": ("cunqa.qpu", "qraise"),
     "qdrop": ("cunqa.qpu", "qdrop"),
-    "gather": ("cunqa.qjob", "gather")
+    "gather": ("cunqa.qjob", "gather"),
+    "BackendAdapter": ("cunqa.netqmpi_adapter", "BackendAdapter"),
+    "QMPIComm": ("cunqa.netqmpi_adapter", "QMPIComm"),
+    "CUNQAComm": ("cunqa.netqmpi_adapter", "CUNQAComm"),
+    "NetQASMComm": ("cunqa.netqmpi_adapter", "NetQASMComm"),
 }
 
 __all__ = _submodules + list(_lazy_symbols.keys()) + ["__version__"]

--- a/cunqa/netqmpi_adapter.py
+++ b/cunqa/netqmpi_adapter.py
@@ -1,0 +1,197 @@
+"""Adapter layer to plug CUNQA and NetQASM under a QMPI-like communication API.
+
+This module introduces a lightweight backend abstraction inspired by the
+NetQMPI architecture sketch:
+
+- A common communication facade (``QMPIComm``)
+- A backend adapter selecting a concrete backend implementation
+- Concrete backends for CUNQA and NetQASM
+
+The implementation is intentionally transport-agnostic: users can provide
+``send``/``recv`` callables from their runtime (MPI, sockets, RPC, etc.) and
+reuse the same QMPI-facing flow.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Optional
+
+
+InitFn = Callable[[], None]
+FinalizeFn = Callable[[], None]
+SendFn = Callable[[Any, int, int], None]
+RecvFn = Callable[[int, int], Any]
+BarrierFn = Callable[[], None]
+
+
+class CommunicationBackend:
+    """Interface expected by :class:`QMPIComm`."""
+
+    def init(self) -> None:
+        """Initialize backend resources."""
+
+    def finalize(self) -> None:
+        """Finalize backend resources."""
+
+    def send(self, payload: Any, dst: int, tag: int = 0) -> None:
+        """Send ``payload`` to destination rank ``dst``."""
+
+    def recv(self, src: int, tag: int = 0) -> Any:
+        """Receive a payload from source rank ``src``."""
+
+    def barrier(self) -> None:
+        """Synchronize all participants."""
+
+
+@dataclass
+class _CallableBackend(CommunicationBackend):
+    """Base backend that delegates communication primitives to callables."""
+
+    name: str
+    send_fn: SendFn
+    recv_fn: RecvFn
+    init_fn: Optional[InitFn] = None
+    finalize_fn: Optional[FinalizeFn] = None
+    barrier_fn: Optional[BarrierFn] = None
+
+    def init(self) -> None:
+        if self.init_fn:
+            self.init_fn()
+
+    def finalize(self) -> None:
+        if self.finalize_fn:
+            self.finalize_fn()
+
+    def send(self, payload: Any, dst: int, tag: int = 0) -> None:
+        self.send_fn(payload, dst, tag)
+
+    def recv(self, src: int, tag: int = 0) -> Any:
+        return self.recv_fn(src, tag)
+
+    def barrier(self) -> None:
+        if self.barrier_fn:
+            self.barrier_fn()
+
+
+class CUNQAComm(_CallableBackend):
+    """CUNQA-backed communicator implementation."""
+
+    def __init__(
+        self,
+        send_fn: SendFn,
+        recv_fn: RecvFn,
+        init_fn: Optional[InitFn] = None,
+        finalize_fn: Optional[FinalizeFn] = None,
+        barrier_fn: Optional[BarrierFn] = None,
+    ) -> None:
+        super().__init__(
+            name="cunqa",
+            send_fn=send_fn,
+            recv_fn=recv_fn,
+            init_fn=init_fn,
+            finalize_fn=finalize_fn,
+            barrier_fn=barrier_fn,
+        )
+
+
+class NetQASMComm(_CallableBackend):
+    """NetQASM-backed communicator implementation."""
+
+    def __init__(
+        self,
+        send_fn: SendFn,
+        recv_fn: RecvFn,
+        init_fn: Optional[InitFn] = None,
+        finalize_fn: Optional[FinalizeFn] = None,
+        barrier_fn: Optional[BarrierFn] = None,
+    ) -> None:
+        super().__init__(
+            name="netqasm",
+            send_fn=send_fn,
+            recv_fn=recv_fn,
+            init_fn=init_fn,
+            finalize_fn=finalize_fn,
+            barrier_fn=barrier_fn,
+        )
+
+
+class BackendAdapter:
+    """Factory/adapter that returns the backend requested by NetQMPI code."""
+
+    def __init__(self, backend: CommunicationBackend):
+        self._backend = backend
+
+    @property
+    def backend(self) -> CommunicationBackend:
+        return self._backend
+
+    @classmethod
+    def from_name(
+        cls,
+        backend_name: str,
+        *,
+        send_fn: SendFn,
+        recv_fn: RecvFn,
+        init_fn: Optional[InitFn] = None,
+        finalize_fn: Optional[FinalizeFn] = None,
+        barrier_fn: Optional[BarrierFn] = None,
+    ) -> "BackendAdapter":
+        normalized = backend_name.strip().lower()
+        if normalized == "cunqa":
+            backend = CUNQAComm(
+                send_fn=send_fn,
+                recv_fn=recv_fn,
+                init_fn=init_fn,
+                finalize_fn=finalize_fn,
+                barrier_fn=barrier_fn,
+            )
+        elif normalized == "netqasm":
+            backend = NetQASMComm(
+                send_fn=send_fn,
+                recv_fn=recv_fn,
+                init_fn=init_fn,
+                finalize_fn=finalize_fn,
+                barrier_fn=barrier_fn,
+            )
+        else:
+            raise ValueError(
+                f"Unsupported backend '{backend_name}'. Use 'cunqa' or 'netqasm'."
+            )
+        return cls(backend)
+
+
+class QMPIComm:
+    """QMPI-like facade that talks to a pluggable backend via ``BackendAdapter``."""
+
+    def __init__(self, adapter: BackendAdapter):
+        self._adapter = adapter
+        self._initialized = False
+
+    def MPI_Init(self) -> None:
+        """Compatibility no-op to mirror MPI init call ordering."""
+
+    def QMPI_Init(self) -> None:
+        self._adapter.backend.init()
+        self._initialized = True
+
+    def send(self, payload: Any, dst: int, tag: int = 0) -> None:
+        self._ensure_initialized()
+        self._adapter.backend.send(payload, dst, tag)
+
+    def recv(self, src: int, tag: int = 0) -> Any:
+        self._ensure_initialized()
+        return self._adapter.backend.recv(src, tag)
+
+    def barrier(self) -> None:
+        self._ensure_initialized()
+        self._adapter.backend.barrier()
+
+    def finalize(self) -> None:
+        if self._initialized:
+            self._adapter.backend.finalize()
+            self._initialized = False
+
+    def _ensure_initialized(self) -> None:
+        if not self._initialized:
+            raise RuntimeError("QMPI_Init must be called before communication primitives.")

--- a/tests/test_netqmpi_adapter.py
+++ b/tests/test_netqmpi_adapter.py
@@ -1,0 +1,78 @@
+from cunqa.netqmpi_adapter import BackendAdapter, QMPIComm
+
+
+def test_backend_adapter_cunqa_send_recv_flow():
+    sent = []
+
+    def send_fn(payload, dst, tag):
+        sent.append((payload, dst, tag))
+
+    def recv_fn(src, tag):
+        return {"src": src, "tag": tag, "value": "ok"}
+
+    adapter = BackendAdapter.from_name("cunqa", send_fn=send_fn, recv_fn=recv_fn)
+    comm = QMPIComm(adapter)
+
+    comm.MPI_Init()
+    comm.QMPI_Init()
+    comm.send("hello", dst=2, tag=7)
+    msg = comm.recv(src=3, tag=5)
+
+    assert sent == [("hello", 2, 7)]
+    assert msg == {"src": 3, "tag": 5, "value": "ok"}
+
+
+def test_backend_adapter_netqasm_lifecycle_hooks_are_called():
+    events = []
+
+    def init_fn():
+        events.append("init")
+
+    def finalize_fn():
+        events.append("finalize")
+
+    def send_fn(payload, dst, tag):
+        events.append(("send", payload, dst, tag))
+
+    def recv_fn(src, tag):
+        events.append(("recv", src, tag))
+        return "answer"
+
+    adapter = BackendAdapter.from_name(
+        "netqasm",
+        send_fn=send_fn,
+        recv_fn=recv_fn,
+        init_fn=init_fn,
+        finalize_fn=finalize_fn,
+    )
+    comm = QMPIComm(adapter)
+    comm.QMPI_Init()
+    comm.send(payload=123, dst=4, tag=1)
+    assert comm.recv(src=4, tag=1) == "answer"
+    comm.finalize()
+
+    assert events == [
+        "init",
+        ("send", 123, 4, 1),
+        ("recv", 4, 1),
+        "finalize",
+    ]
+
+
+def test_comm_requires_qmpi_init():
+    def send_fn(payload, dst, tag):
+        return None
+
+    def recv_fn(src, tag):
+        return None
+
+    adapter = BackendAdapter.from_name("cunqa", send_fn=send_fn, recv_fn=recv_fn)
+    comm = QMPIComm(adapter)
+
+    try:
+        comm.send("x", dst=1)
+        raised = False
+    except RuntimeError:
+        raised = True
+
+    assert raised


### PR DESCRIPTION
### Motivation
- Provide a NetQMPI-style adapter so NetQMPI code can target either CUNQA or NetQASM as interchangeable communication backends. 
- Make the integration transport-agnostic so runtime-specific `send`/`recv` can be provided by MPI, sockets, or other transports.

### Description
- Added a new module `cunqa/netqmpi_adapter.py` implementing `QMPIComm`, `BackendAdapter`, `CUNQAComm`, and `NetQASMComm` that delegate primitives to user-provided callables (`send_fn`, `recv_fn`, `init_fn`, `finalize_fn`, `barrier_fn`).
- Exported the adapter API at the top-level by updating `cunqa/__init__.py` to expose `BackendAdapter`, `QMPIComm`, `CUNQAComm`, and `NetQASMComm` for `from cunqa import ...` usage.
- Documented the new adapter and added a minimal usage snippet in `README.md` under a new section `NetQMPI adapter (CUNQA + NetQASM)`.
- Added unit tests in `tests/test_netqmpi_adapter.py` to verify send/recv flow, lifecycle hooks (`init`/`finalize`), and that communication primitives require prior `QMPI_Init`.

### Testing
- Ran `pytest -q tests/test_netqmpi_adapter.py` initially which failed at collection due to module import path in the test environment (resolved by running with local package path).
- Ran `PYTHONPATH=. pytest -q tests/test_netqmpi_adapter.py` and observed all tests pass (3 passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a14a7c3568832782cf2c8e596e8bbd)