### PR TITLE
ZMQ sockets change to dealer-router

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,30 +145,57 @@ find_or_fetch_package(
 # =====================================================================
 
 # -- libzmq -----------------------------------------------------------
-set(WITH_DOCS OFF               CACHE BOOL "Disable docs"               FORCE)
-set(ENABLE_CPACK OFF            CACHE BOOL "Disable CPACK"              FORCE)
-set(WITH_PERF_TOOL OFF          CACHE BOOL "Disable performance tool"   FORCE)
-set(ZMQ_BUILD_TESTS OFF         CACHE BOOL "Disable tests"              FORCE)
-set(ENABLE_DRAFTS ON            CACHE BOOL "Enable drafts"              FORCE)
-set(BUILD_SHARED ON             CACHE BOOL "Build shared library"       FORCE)
-set(BUILD_STATIC OFF            CACHE BOOL "Build static library"       FORCE)
+include(FetchContent)
 
-find_or_fetch_package(
-  libzmq
-  "git@github.com:zeromq/libzmq.git"
-  "4.3.5"
-  "v4.3.5"
-)
+find_package(libzmq 4.3.5 QUIET)
+if(NOT ${PACKAGE_NAME}_FOUND)
+# Force options for minimal libzmq build
+  set(WITH_DOCS OFF CACHE BOOL "" FORCE)
+  set(WITH_PERF_TOOL OFF CACHE BOOL "" FORCE)
+  set(ZMQ_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+  set(WITH_GNUTLS OFF CACHE BOOL "" FORCE)  # avoid optional TLS dependency
+  set(BUILD_SHARED ON CACHE BOOL "" FORCE)
+  set(BUILD_STATIC OFF CACHE BOOL "" FORCE)
 
-# -- cppzmq -----------------------------------------------------------
-set(CPPZMQ_BUILD_TESTS OFF      CACHE BOOL "Disable tests"              FORCE)
+  # Fetch libzmq
+  FetchContent_Declare(
+    libzmq
+    GIT_REPOSITORY https://github.com/zeromq/libzmq.git
+    GIT_TAG v4.3.5
+  )
 
-find_or_fetch_package(
-  cppzmq
-  "git@github.com:zeromq/cppzmq.git"
-  "4.11.0"
-  "v4.11.0"
-)
+  FetchContent_GetProperties(libzmq)
+  if(NOT libzmq_POPULATED)
+    FetchContent_Populate(libzmq)
+    add_subdirectory(${libzmq_SOURCE_DIR} ${libzmq_BINARY_DIR})
+  endif()
+  if(TARGET libzmq)
+    message(STATUS "libzmq target exists")
+  else()
+    message(STATUS "libzmq target DOES NOT exist")
+  endif()
+else()
+  message(STATUS "Found package libzmq: libzmq_DIR = ${libzmq_DIR}")
+endif()
+
+#-- cppzmq ------------------------------------------------------------
+find_package(cppzmq 4.9.0 QUIET)
+if(NOT cppzmq_FOUND)
+  set(CPPZMQ_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+  FetchContent_Declare(
+    cppzmq
+    GIT_REPOSITORY https://github.com/zeromq/cppzmq.git
+    GIT_TAG v4.9.0
+  )
+
+  FetchContent_GetProperties(cppzmq)
+  if(NOT cppzmq_POPULATED)
+    FetchContent_Populate(cppzmq)
+    add_subdirectory(${cppzmq_SOURCE_DIR} ${cppzmq_BINARY_DIR})
+  endif()
+else()
+  message(STATUS "Found package cppzmq: cppzmq_DIR = ${cppzmq_DIR}")
+endif()
 
 # -- pyzmq -----------------------------------------------------------
 set(ZeroMQ_DIR "${libzmq_BINARY_DIR}" CACHE PATH "Path to ZeroMQConfig.cmake" FORCE)

--- a/src/backends/simulators/AER/aer_adapters/aer_simulator_adapter.cpp
+++ b/src/backends/simulators/AER/aer_adapters/aer_simulator_adapter.cpp
@@ -568,7 +568,9 @@ JSON AerSimulatorAdapter::simulate(comm::ClassicalChannel* classical_channel)
     state.configure("method", sim_method);
     state.configure("device", device);
     state.configure("precision", "double");
-    state.configure("seed_simulator", std::to_string(qc.quantum_tasks[0].config.at("seed").get<int>()));
+    if (qc.quantum_tasks[0].config.contains("seed")) {
+        state.configure("seed_simulator", std::to_string(qc.quantum_tasks[0].config.at("seed").get<int>()));
+    }
     reg_t target_gpus = (device == "GPU") ? qc.quantum_tasks[0].config.at("device")["target_devices"].get<reg_t>() : reg_t();
 
     unsigned long n_qubits = 0;

--- a/src/backends/simulators/AER/aer_helpers.hpp
+++ b/src/backends/simulators/AER/aer_helpers.hpp
@@ -126,9 +126,11 @@ QuantumTask quantum_task_to_AER(const QuantumTask& quantum_task)
     new_config["memory_slots"] = mem_slots;
 
     // Avoid parallelization. Not recommended.
-    if (quantum_task.config.at("avoid_parallelization").get<bool>()) {
-        LOGGER_DEBUG("Trhead parallelization canceled");
-        new_config["max_parallel_threads"] = 1;
+    if (quantum_task.config.contains("avoid_parallelization")) {
+        if (quantum_task.config.at("avoid_parallelization").get<bool>()) {
+            LOGGER_DEBUG("Trhead parallelization canceled");
+            new_config["max_parallel_threads"] = 1;
+        }
     }
 
     //JSON Object because if not it generates an array

--- a/src/comm/comm_impl/zmq/zmq_client.cpp
+++ b/src/comm/comm_impl/zmq/zmq_client.cpp
@@ -11,7 +11,7 @@ namespace comm {
     
 struct Client::Impl {
     Impl() :
-        socket_{context_, zmq::socket_type::client}
+        socket_{context_, zmq::socket_type::dealer}
     { }
 
     ~Impl() 
@@ -48,7 +48,6 @@ struct Client::Impl {
             zmq::message_t reply;
             auto size = socket_.recv(reply, zmq::recv_flags::none);
             std::string result(static_cast<char*>(reply.data()), size.value());
-            //LOGGER_DEBUG("Result correctly received: {}", result);
             return result;
         } catch (const zmq::error_t& e) {
             LOGGER_ERROR("Error receiving the circuit: {}", e.what());
@@ -63,7 +62,7 @@ struct Client::Impl {
             socket_.disconnect(endpoint);
         } else {
             socket_.close();
-            socket_ = zmq::socket_t(context_, zmq::socket_type::client);
+            socket_ = zmq::socket_t(context_, zmq::socket_type::dealer);
         }
     }
 

--- a/src/comm/comm_impl/zmq/zmq_server.cpp
+++ b/src/comm/comm_impl/zmq/zmq_server.cpp
@@ -10,12 +10,12 @@ namespace comm {
 struct Server::Impl {
     zmq::context_t context_;
     zmq::socket_t socket_;
-    std::queue<uint32_t> rid_queue_;
+    std::queue<std::string> rid_queue_;
 
     std::string zmq_endpoint;
 
     Impl(const std::string& mode) :
-        socket_{context_, zmq::socket_type::server}
+        socket_{context_, zmq::socket_type::router}
     {
         try {
             std::string ip = (mode == "hpc" ? "127.0.0.1"s : get_IP_address());
@@ -36,10 +36,18 @@ struct Server::Impl {
     std::string recv() 
     { 
         try {
+            zmq::message_t identity;
+            auto id_size = socket_.recv(identity, zmq::recv_flags::none);
+            std::string id_data(static_cast<char*>(identity.data()), id_size.value());
+            rid_queue_.push(id_data);
+
+            int more = 0;
+            size_t more_size = sizeof(more);
+            socket_.getsockopt(ZMQ_RCVMORE, &more, &more_size);
+
             zmq::message_t message;
             auto size = socket_.recv(message, zmq::recv_flags::none);
             std::string data(static_cast<char*>(message.data()), size.value());
-            rid_queue_.push(message.routing_id());
             return data;
         } catch (const zmq::error_t& e) {
             LOGGER_ERROR("Error receiving data: {}", e.what());
@@ -51,9 +59,12 @@ struct Server::Impl {
     {
         try {
             zmq::message_t message(result.begin(), result.end());
-            message.set_routing_id(rid_queue_.front());
+            //message.set_routing_id(rid_queue_.front());
+            std::string recvr_id = rid_queue_.front();
             rid_queue_.pop();
-            
+            zmq::message_t identity_frame(recvr_id.begin(), recvr_id.end());
+
+            socket_.send(identity_frame, zmq::send_flags::sndmore);
             socket_.send(message, zmq::send_flags::none);
             //LOGGER_DEBUG("Sent result: {}", result);
         } catch (const zmq::error_t& e) {


### PR DESCRIPTION
1. ZMQ socket pair changed from client-server to dealer-router.
2. Better management of libzmq and cppzmq fetching. 
3. Small bug with seed in aer dynamic execution