### PR TITLE
Return counts as a Counter object to provide useful functionalities

### DIFF
--- a/cunqa/result.py
+++ b/cunqa/result.py
@@ -19,6 +19,7 @@
 import numpy as np
 from typing import Union
 from itertools import accumulate
+from collections import Counter
 
 class Result:
     """
@@ -108,15 +109,15 @@ class Result:
             raise RuntimeError(f"The result format is unknown: no counts in it.")
         
         if len(self._registers) == 1:
-            return counts
+            return Counter(counts)
 
         # reversed to keep the order of counts keys
         lengths = [len(reg) for reg in reversed(self._registers.values())]
         if not lengths:
             return counts
         cuts = (0, *accumulate(lengths))
-        return {' '.join(bitstring[i:j] for i, j in zip(cuts, cuts[1:])): 
-                count for bitstring, count in counts.items()}
+        return Counter({' '.join(bitstring[i:j] for i, j in zip(cuts, cuts[1:])): 
+                count for bitstring, count in counts.items()})
 
     @property
     def time_taken(self) -> str:

--- a/tests/circuit/test_transformations.py
+++ b/tests/circuit/test_transformations.py
@@ -29,7 +29,7 @@ class FakeQuantumControlContext:
 
     def __enter__(self):
         self._subcircuit = FakeCircuit(self.target_circuit.num_qubits, self.target_circuit.num_clbits)
-        return -1, self._subcircuit
+        return [-1], self._subcircuit
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         rcontrol = {


### PR DESCRIPTION
Counts are returned as a `Counter` object from collections (no new dependencies). `Counter`s are `dict`s with extra functionalities: 

- Two `Counter` dicts can be "summed" easily with `counter1.update(counter2)` or substracted with `.subtract()` (this won't return negative values tho, staying at zero).
- Method `.most_common(n = 4)` returns the keys with the 4 highest values
- `isinstance(counter1, dict)` returns `True`
- `total()` returns the total value of the counter, in our case the number of shots

All of this will be more performant than a manual implementation and there are no obvious drawbacks, apparently.
