### PR TITLE
has_qc, has_cc, instance tracking

### DIFF
--- a/cunqa/circuit/core.py
+++ b/cunqa/circuit/core.py
@@ -270,9 +270,7 @@ class CunqaCircuit:
 
 
         
-    """
-    instances = {}
-    
+    """    
     # global attributes
     _ids: set = set() #: Set with ids in use.
     _communicated: dict[str, CunqaCircuit] = {} #: Dictionary with the circuits that employ communication directives.
@@ -301,6 +299,7 @@ class CunqaCircuit:
         self.quantum_regs = {}
         self.classical_regs = {}        
         self.sending_to = set()
+        self.components_comm = {}
 
         self.add_q_register("q0", num_qubits)
         
@@ -315,8 +314,6 @@ class CunqaCircuit:
                            f"generated one: {self._id}.")
         else:
             self._id = id
-
-        CunqaCircuit.instances[self._id] = self
 
     @property
     def id(self) -> str:
@@ -339,7 +336,8 @@ class CunqaCircuit:
             "has_cc": self.has_cc, 
             "has_qc": self.has_qc, 
             "sending_to": list(self.sending_to),
-            "params": self.params
+            "params": self.params,
+            "component_comms": self.components_comm
         }
 
     @property

--- a/cunqa/circuit/ir.py
+++ b/cunqa/circuit/ir.py
@@ -68,7 +68,8 @@ def _(c: QuantumCircuit) -> dict:
         "num_clbits": sum([c.size for c in c.cregs]),
         "quantum_registers": quantum_registers,
         "classical_registers": classical_registers, 
-        "params":[]
+        "params":[],
+        "component_comms": {}
     }
 
     for instruction in c.data:

--- a/cunqa/circuit/transformations.py
+++ b/cunqa/circuit/transformations.py
@@ -270,6 +270,15 @@ def union(circuits: list[CunqaCircuit]) -> CunqaCircuit:
             if consumed:
                 advance(idx)
 
+    # Store info about whether the component circuits have communications for exceptions in run method
+    components_comm = {}
+    for circ in circuits:
+        if len(circ.components_comm) != 0:
+            components_comm.update(circ.components_comm)
+        else:
+            components_comm[circ.id] = (circ.has_cc or circ.has_qc)
+    union_circuit.components_comm = components_comm
+
     union_circuit.add_instructions(union_instructions)
     return union_circuit
 
@@ -311,6 +320,15 @@ def add(circuits: list[CunqaCircuit]) -> CunqaCircuit:
                     if circ_id in circuit_ids:
                         raise ValueError("Cannot add two circuits that communicate with eachother.")
             addition_instructions.append(instr)
+
+    # Store info about whether the component circuits have communications for exceptions in run method
+    components_comm = {}
+    for circ in circuits:
+        if len(circ.components_comm) != 0:
+            components_comm.update(circ.components_comm)
+        else:
+            components_comm[circ.id] = (circ.has_cc or circ.has_qc)
+    addition_circuit.components_comm = components_comm
 
     addition_circuit.add_instructions(addition_instructions)
     return addition_circuit        

--- a/cunqa/qpu.py
+++ b/cunqa/qpu.py
@@ -187,7 +187,7 @@ def run(
     else:
         circuits_ir = [to_ir(circuits)]
 
-    def expand_mapping(items: list[str]) -> dict[str, str]:
+    def expand_mapping(items: list[str], components_comm: dict[bool]) -> dict[str, str]:
         def split(item: str) -> list[str]:
             return [p for p in re.split(r"[|+]", item) if p]
 
@@ -197,10 +197,10 @@ def run(
             occurrences.update(set(split(item)))
 
         conflicts      = {item for item, count in occurrences.items() if count >= 2}
-        conflict_circs = [CunqaCircuit.instances[confl] for confl in conflicts]
+        conflict_comms = [true_false for circ_id, true_false in components_comm.items() if circ_id in conflicts]
 
         # Raise error if any conflict circuit has communications
-        if conflicts and any([(c.has_cc or c.has_qc) for c in conflict_circs]):
+        if conflicts and any(conflict_comms):
             raise ValueError(f"Conflicting identifiers found: {sorted(conflicts)}")
 
         return {
@@ -223,9 +223,15 @@ def run(
     elif len(circuits_ir) < len(qpus):
         logger.warning("More QPUs provided than the number of circuits. "
                        "Last QPUs will remain unused.")
+        
+    # Needed for union and add compatibility check
+    components_comm = {}
+    for circ in circuits_ir:
+        if "components_comm" in circ:
+            components_comm.update(circ["components_comm"])
     
     # translate circuit ids in comm instruction to qpu endpoints
-    transformed_circs = expand_mapping([c["id"] for c in circuits_ir])
+    transformed_circs = expand_mapping([c["id"] for c in circuits_ir], components_comm)
     correspondence = {c["id"]: qpus[i].id for i, c in enumerate(circuits_ir)}
     for circuit in circuits_ir:
         for instr in circuit["instructions"]:

--- a/tests/circuit/test_transformations.py
+++ b/tests/circuit/test_transformations.py
@@ -51,6 +51,9 @@ class FakeCircuit:
         self.instructions = []
         self.is_dynamic = False
         self._expose_calls = []
+        self.components_comm = {}
+        self.has_cc = False
+        self.has_qc = False
 
     @property
     def info(self):


### PR DESCRIPTION
- Brought back has_cc and has_qc as circuit attributes.
- Fixed the trigger-happy error raising when executing circuits that are the result of `union` or `add`.
- Brought back the instance tracker in a lightweight form to handle conflicts on the previous point.

Some of these decisions may not raise consensus, evaluate whether this is the way to go.