### PR TITLE
Corrected the bug of sending the same circuit to several QC vQPUs

### DIFF
--- a/examples/python/no_comm/01-complete_workflow.py
+++ b/examples/python/no_comm/01-complete_workflow.py
@@ -24,11 +24,10 @@ try:
     #                 |      
     #  qc.q1   ──────[X]───[M]─
     # ---------------------------
-    qc = CunqaCircuit(5)
+    qc = CunqaCircuit(2)
     qc.h(0)
     qc.cx(0, 1)
     qc.measure_all()
-    #qc.is_dynamic = True
 
     # 3. Execute the same circuit on both deployed QPUs
     qjobs = run([qc, qc], qpus, shots = 10) # non-blocking call

--- a/src/backends/simulators/AER/aer_adapters/aer_simulator_adapter.cpp
+++ b/src/backends/simulators/AER/aer_adapters/aer_simulator_adapter.cpp
@@ -119,7 +119,7 @@ std::vector<int> find_my_communication_pairs(const GlobalState& G, const std::st
 
 std::string execute_shot_(
     AER::AerState* state, 
-    const std::vector<StructuredQuantumTask>& st_qtasks,
+    std::vector<StructuredQuantumTask>& st_qtasks,
     comm::ClassicalChannel* classical_channel,
     const bool allows_qc,
     const size_t& n_comm_qubits
@@ -128,6 +128,7 @@ std::string execute_shot_(
     std::unordered_map<std::string, TaskState> Ts;
     GlobalState G;
 
+    int qt_count = 0;
     for (auto &quantum_task : st_qtasks) {
         TaskState T;
         T.id = quantum_task.id;
@@ -139,10 +140,15 @@ std::string execute_shot_(
         T.blocked_by_telegate = false;
         T.blocked_by_cc = false;
         T.finished = false;
+        if (Ts.count(quantum_task.id)) {
+            quantum_task.id += "_" + std::to_string(qt_count); 
+        }
         Ts[quantum_task.id] = T;
         
         G.n_qubits += quantum_task.n_qubits;
         G.n_clbits += quantum_task.n_clbits;
+
+        qt_count++;
     }
     
     // Here we add the communication qubits

--- a/src/backends/simulators/CUNQA/cunqa_adapters/cunqa_simulator_adapter.cpp
+++ b/src/backends/simulators/CUNQA/cunqa_adapters/cunqa_simulator_adapter.cpp
@@ -115,7 +115,7 @@ std::vector<int> find_my_communication_pairs(const GlobalState& G, const std::st
 
 std::string execute_shot_(
     Executor& executor, 
-    const std::vector<StructuredQuantumTask>& st_qtasks, 
+    std::vector<StructuredQuantumTask>& st_qtasks, 
     cunqa::comm::ClassicalChannel* classical_channel,
     const bool allows_qc, 
     const size_t& n_comm_qubits
@@ -124,6 +124,7 @@ std::string execute_shot_(
     std::unordered_map<std::string, TaskState> Ts;
     GlobalState G;
 
+    int qt_count = 0;
     for (auto &quantum_task : st_qtasks) {
         TaskState T;
         T.id = quantum_task.id;
@@ -135,10 +136,15 @@ std::string execute_shot_(
         T.blocked_by_telegate = false;
         T.blocked_by_cc = false;
         T.finished = false;
+        if (Ts.count(quantum_task.id)) {
+            quantum_task.id += "_" + std::to_string(qt_count); 
+        }
         Ts[quantum_task.id] = T;
         
         G.n_qubits += quantum_task.n_qubits;
         G.n_clbits += quantum_task.n_clbits;
+
+        qt_count++;
     }
     
     // Here we add the communication qubits

--- a/src/backends/simulators/Maestro/maestro_adapters/maestro_simulator_adapter.cpp
+++ b/src/backends/simulators/Maestro/maestro_adapters/maestro_simulator_adapter.cpp
@@ -112,7 +112,7 @@ std::vector<int> find_my_communication_pairs(const GlobalState& G, const std::st
 
 std::string execute_shot_(
     void* simulator, 
-    const std::vector<StructuredQuantumTask>& st_qtasks, 
+    std::vector<StructuredQuantumTask>& st_qtasks, 
     cunqa::comm::ClassicalChannel* classical_channel,
     const bool allows_qc, 
     const size_t& n_comm_qubits
@@ -121,6 +121,7 @@ std::string execute_shot_(
     std::unordered_map<std::string, TaskState> Ts;
     GlobalState G;
 
+    int qt_count = 0;
     for (auto &quantum_task : st_qtasks) {
         TaskState T;
         T.id = quantum_task.id;
@@ -132,10 +133,15 @@ std::string execute_shot_(
         T.blocked_by_telegate = false;
         T.blocked_by_cc = false;
         T.finished = false;
+        if (Ts.count(quantum_task.id)) {
+            quantum_task.id += "_" + std::to_string(qt_count); 
+        }
         Ts[quantum_task.id] = T;
         
         G.n_qubits += quantum_task.n_qubits;
         G.n_clbits += quantum_task.n_clbits;
+
+        qt_count++;
     }
     
     // Here we add the communication qubits

--- a/src/backends/simulators/Munich/munich_adapters/munich_simulator_adapter.cpp
+++ b/src/backends/simulators/Munich/munich_adapters/munich_simulator_adapter.cpp
@@ -118,7 +118,7 @@ using namespace constants;
 
 
 std::string MunichSimulatorAdapter::execute_shot_(
-    const std::vector<StructuredQuantumTask>& st_qtasks, 
+    std::vector<StructuredQuantumTask>& st_qtasks, 
     comm::ClassicalChannel *classical_channel,
     const bool allows_qc,
     const size_t& n_comm_qubits
@@ -127,6 +127,7 @@ std::string MunichSimulatorAdapter::execute_shot_(
     std::unordered_map<std::string, TaskState> Ts;
     GlobalState G;
     
+    int qt_count = 0;
     for (auto &quantum_task : st_qtasks) {
         TaskState T;
         T.id = quantum_task.id;
@@ -138,10 +139,14 @@ std::string MunichSimulatorAdapter::execute_shot_(
         T.blocked_by_telegate = false;
         T.blocked_by_cc = false;
         T.finished = false;
+        if (Ts.count(quantum_task.id)) {
+            quantum_task.id += "_" + std::to_string(qt_count); 
+        }
         Ts[quantum_task.id] = T;
-        
         G.n_qubits += quantum_task.n_qubits;
         G.n_clbits += quantum_task.n_clbits;
+
+        qt_count++;
     }
     
     // Here we add the communication qubits
@@ -187,7 +192,6 @@ std::string MunichSimulatorAdapter::execute_shot_(
     {
         const CUNQAInstruction inst = !instruction.has_value() ? *T.it : instruction.value();
         auto inst_type = INSTRUCTIONS_MAP.at(inst.name);
-
         
         switch (inst_type) {
         case constants::MEASURE:

--- a/src/backends/simulators/Munich/munich_adapters/munich_simulator_adapter.hpp
+++ b/src/backends/simulators/Munich/munich_adapters/munich_simulator_adapter.hpp
@@ -34,7 +34,7 @@ public:
 private:
 
     std::string execute_shot_(
-        const std::vector<StructuredQuantumTask>& st_qtasks, 
+        std::vector<StructuredQuantumTask>& st_qtasks, 
         comm::ClassicalChannel* classical_channel,
         const bool allows_qc,
         const size_t& n_comm_qubits

--- a/src/backends/simulators/Qsim/qsim_adapters/qsim_simulator_adapter.cpp
+++ b/src/backends/simulators/Qsim/qsim_adapters/qsim_simulator_adapter.cpp
@@ -150,7 +150,7 @@ std::string execute_shot_(
     qsim::SimulatorBasic<qsim::ParallelFor>::State& state,
     qsim::SimulatorBasic<qsim::ParallelFor>& simulator,
     std::mt19937& rgen,
-    const std::vector<StructuredQuantumTask>& st_qtasks, 
+    std::vector<StructuredQuantumTask>& st_qtasks, 
     cunqa::comm::ClassicalChannel* classical_channel,
     const bool allows_qc, 
     const size_t& n_comm_qubits
@@ -159,6 +159,7 @@ std::string execute_shot_(
     std::unordered_map<std::string, TaskState> Ts;
     GlobalState G;
 
+    int qt_count = 0;
     for (auto &quantum_task : st_qtasks) {
         TaskState T;
         T.id = quantum_task.id;
@@ -170,10 +171,15 @@ std::string execute_shot_(
         T.blocked_by_telegate = false;
         T.blocked_by_cc = false;
         T.finished = false;
+        if (Ts.count(quantum_task.id)) {
+            quantum_task.id += "_" + std::to_string(qt_count); 
+        }
         Ts[quantum_task.id] = T;
         
         G.n_qubits += quantum_task.n_qubits;
         G.n_clbits += quantum_task.n_clbits;
+
+        qt_count++;
     }
     
     // Here we add the communication qubits

--- a/src/backends/simulators/Qulacs/qulacs_adapters/qulacs_simulator_adapter.cpp
+++ b/src/backends/simulators/Qulacs/qulacs_adapters/qulacs_simulator_adapter.cpp
@@ -147,7 +147,7 @@ std::vector<int> find_my_communication_pairs(const GlobalState& G, const std::st
 
 std::string execute_shot_(
     QuantumState& state, 
-    const std::vector<StructuredQuantumTask>& st_qtasks, 
+    std::vector<StructuredQuantumTask>& st_qtasks, 
     cunqa::comm::ClassicalChannel* classical_channel,
     const bool allows_qc,
     const size_t& n_comm_qubits
@@ -156,6 +156,7 @@ std::string execute_shot_(
     std::unordered_map<std::string, TaskState> Ts;
     GlobalState G;
 
+    int qt_count = 0;
     for (auto &quantum_task : st_qtasks) {
         TaskState T;
         T.id = quantum_task.id;
@@ -167,10 +168,15 @@ std::string execute_shot_(
         T.blocked_by_telegate = false;
         T.blocked_by_cc = false;
         T.finished = false;
+        if (Ts.count(quantum_task.id)) {
+            quantum_task.id += "_" + std::to_string(qt_count); 
+        }
         Ts[quantum_task.id] = T;
         
         G.n_qubits += quantum_task.n_qubits;
         G.n_clbits += quantum_task.n_clbits;
+
+        qt_count++;
     }
     
     // Here we add the communication qubits


### PR DESCRIPTION
The problem happened when the same circuit (or different circuits with same ids) were sent to several vQPUs with quantum communications. 

In `execute_shot_()` function of each adapter, the line `Ts[quantum_task.id] = T;` was overriding the same circuit, so one single circuit was executed.

**Solution:** Added the following control: 
```c++
if (Ts.count(quantum_task.id)) {
    quantum_task.id += "_" + std::to_string(qt_count); 
}
``` 