### PR TITLE
Corrected bug when executing normal circuit with CC in Aer and Munich

### DIFF
--- a/src/backends/simulators/AER/aer_adapters/aer_simulator_adapter.cpp
+++ b/src/backends/simulators/AER/aer_adapters/aer_simulator_adapter.cpp
@@ -864,7 +864,10 @@ JSON AerSimulatorAdapter::simulate(const Backend* backend)
             run_config_json["seed_simulator"] = quantum_task.config.at("seed");
         }
         Config aer_config(run_config_json);
-        Noise::NoiseModel noise_model(backend->config.at("noise_model"));
+        Noise::NoiseModel noise_model;
+        if (backend->config.contains("noise_model")) {
+            noise_model.load_from_json(backend->config.at("noise_model").get<JSON>());
+        }
 
         Result result = controller_execute<Controller>(circuits, noise_model, aer_config);
 

--- a/src/backends/simulators/Munich/munich_adapters/munich_simulator_adapter.cpp
+++ b/src/backends/simulators/Munich/munich_adapters/munich_simulator_adapter.cpp
@@ -652,7 +652,11 @@ JSON MunichSimulatorAdapter::simulate(const Backend* backend)
         quantum_task_to_mqt_circuit(quantum_task.circuit, *mqt_circuit);
         
         float time_taken;
-        JSON noise_model_json = backend->config.at("noise_model");
+
+        JSON noise_model_json = {};
+        if (backend->config.contains("noise_model")) {
+            noise_model_json = backend->config.at("noise_model").get<JSON>();
+        }
         if (!noise_model_json.empty()) {
             const ApproximationInfo approx_info{noise_model_json["step_fidelity"], noise_model_json["approx_steps"], ApproximationInfo::FidelityDriven};
             StochasticNoiseSimulator sim(std::move(mqt_circuit), approx_info, seed, "APD", noise_model_json["noise_prob"],


### PR DESCRIPTION
Noise model was bad managed because it always tried to take the key "noise_model" from the backend config.

Now, the situation when the backend does not have that key is managed by setting the noise model as an empty json.