### PR TITLE
Multi clbit cif with "and", "or" and "xor" expressions

### DIFF
--- a/cunqa/circuit/core.py
+++ b/cunqa/circuit/core.py
@@ -2555,7 +2555,7 @@ class CunqaCircuit:
 class ClassicalControlContext:
     def __init__(self, circuit, clbits: Union[int, list[int]], condition: int = 1):
         self._circuit = circuit
-        self._clbits = clbits
+        self._clbits = [clbits] if isinstance(clbits, int) else clbits
         self._condition = condition
     
     def __enter__(self):
@@ -2572,7 +2572,7 @@ class ClassicalControlContext:
 
         cif = {
             "name": "cif",
-            "clbits": [self._clbits],
+            "clbits": self._clbits,
             "instructions": instructions,
             "condition": self._condition
         }

--- a/cunqa/circuit/core.py
+++ b/cunqa/circuit/core.py
@@ -713,7 +713,8 @@ class CunqaCircuit:
     def cif(
             self, 
             clbits: Union[int, list[int]],
-            condition: int = 1
+            condition: int = 1,
+            operation: str = "and"
         ) -> ClassicalControlContext:
         """
         Method for implementing a gate conditioned to a classical measurement. The control qubit 
@@ -737,10 +738,18 @@ class CunqaCircuit:
         may be added in future versions if needed.
 
         Args:
-            clbits (int | list[int]): clbits employed as the condition.
+            clbits (int | list[int]): clbits to match the condition.
+            condition (int): can be 1 or 0. The clbits will have to match this condition 
+                             for the gate to be applied. Default = 1
+            operation (str): can be "and", "or" or "xor". If multiple clbits are provided, their 
+                             measures are operated on with the selected operation and the result is
+                             matched to condition. "and" means all need to match the condition, 
+                             "or" means any of them should match and "xor" means there should be an
+                             odd number of mathching measures. 
         """
         self.is_dynamic = True
-        return ClassicalControlContext(self, clbits, condition)
+        operation = "0" + operation if (condition == 0) else operation
+        return ClassicalControlContext(self, clbits, condition, operation)
     
     # ------------------
     # Unitary operations
@@ -2553,7 +2562,7 @@ class CunqaCircuit:
             })
             
 class ClassicalControlContext:
-    def __init__(self, circuit, clbits: Union[int, list[int]], condition: int = 1):
+    def __init__(self, circuit, clbits: Union[int, list[int]], condition: int = 1, operation = "and"):
         self._circuit = circuit
         self._clbits = [clbits] if isinstance(clbits, int) else clbits
         self._condition = condition

--- a/cunqa/circuit/core.py
+++ b/cunqa/circuit/core.py
@@ -749,7 +749,7 @@ class CunqaCircuit:
         """
         self.is_dynamic = True
         operation = "0" + operation if (condition == 0) else operation
-        return ClassicalControlContext(self, clbits, condition, operation)
+        return ClassicalControlContext(self, clbits, operation, condition)
     
     # ------------------
     # Unitary operations
@@ -2562,10 +2562,11 @@ class CunqaCircuit:
             })
             
 class ClassicalControlContext:
-    def __init__(self, circuit, clbits: Union[int, list[int]], condition: int = 1, operation = "and"):
+    def __init__(self, circuit, clbits: Union[int, list[int]], operation, condition: int = 1):
         self._circuit = circuit
         self._clbits = [clbits] if isinstance(clbits, int) else clbits
         self._condition = condition
+        self._operation = operation
     
     def __enter__(self):
         self._subcircuit = CunqaCircuit(self._circuit.num_qubits)
@@ -2583,7 +2584,8 @@ class ClassicalControlContext:
             "name": "cif",
             "clbits": self._clbits,
             "instructions": instructions,
-            "condition": self._condition
+            "condition": self._condition,
+            "operation": self._operation
         }
         self._circuit.add_instructions(cif)
  

--- a/cunqa/circuit/core.py
+++ b/cunqa/circuit/core.py
@@ -748,7 +748,7 @@ class CunqaCircuit:
                              odd number of mathching measures. 
         """
         self.is_dynamic = True
-        operation = "n" + operation if (condition == 0) else operation
+        operation = (operation + "n") if (condition == 0) else operation
         return ClassicalControlContext(self, clbits, operation, condition)
     
     # ------------------

--- a/cunqa/circuit/core.py
+++ b/cunqa/circuit/core.py
@@ -748,7 +748,7 @@ class CunqaCircuit:
                              odd number of mathching measures. 
         """
         self.is_dynamic = True
-        operation = "0" + operation if (condition == 0) else operation
+        operation = "n" + operation if (condition == 0) else operation
         return ClassicalControlContext(self, clbits, operation, condition)
     
     # ------------------

--- a/examples/python/no_comm/08-multi_cif_example.py
+++ b/examples/python/no_comm/08-multi_cif_example.py
@@ -1,0 +1,67 @@
+import os, sys
+# In order to import cunqa, we append to the search path the cunqa installation path
+sys.path.append(os.getenv("HOME")) # HOME as install path is specific to CESGA
+
+from cunqa.qpu import get_QPUs, qraise, qdrop, run
+from cunqa.circuit import CunqaCircuit
+
+
+try:
+    # 1. Deploy vQPUs
+    family = qraise(1, "01:00:00", simulator = "Aer", co_located = True)
+except Exception as error:
+    raise error
+
+try:
+    [qpu] = get_QPUs(co_located = True, family = family)
+
+
+    # 2. Design circuit:
+    # ---------------------------
+    #  qc.q0   ─[H]───[M]───[M]─
+    #                  ‖     
+    #  qc.q1   ───────[X]───[M]─
+    # ---------------------------
+    qc = CunqaCircuit(5, 5)
+    qc.x(0)
+    qc.measure(0, 0)
+    qc.measure(1, 1)
+
+    # "and" option: gate is applied if all bits match the condition (=1)
+    # as bit 1 is zero, this gate won't be applied (standard MULTICONTROLLED)
+    with qc.cif([0,1], operation="and") as cgates:
+        cgates.x(2)
+
+    # "or" option: gate is applied if any bit matches the condition (=1)
+    # bit 0 is set to one, the gate will be applied
+    with qc.cif([0,1], operation="or") as cgates:
+        cgates.x(3)
+
+    # "xor" option: gate is applied if there is an odd number of matching (=1) bits
+    # only bit 0 is one, the gate will be applied
+    with qc.cif([0,1], operation="xor") as cgates:
+        cgates.x(4)
+
+    # any of the options work with condition=0
+    # bit 0 is one, so not all are zero, so it won't be applied
+    with qc.cif([0,1], operation="and", condition=0) as cgates:
+        cgates.x(2)
+
+    qc.measure(0,0)
+    qc.measure(1,1)
+    qc.measure(2,2)
+    qc.measure(3,3)
+    qc.measure(4,4)
+
+    # 3. Execute circuit on vQPU
+    qjob = run(qc, qpu, shots = 1024)
+    counts = qjob.result.counts
+
+    print("Counts: ", counts)
+
+    # 4. Relinquish resources
+    qdrop(family)
+
+except Exception as error:
+    qdrop(family)
+    raise error

--- a/src/backends/simulators/AER/aer_adapters/aer_simulator_adapter.cpp
+++ b/src/backends/simulators/AER/aer_adapters/aer_simulator_adapter.cpp
@@ -684,11 +684,24 @@ std::unordered_map<std::string, std::string> execute_shot_(
         }
         case constants::CIF:
         {
-            // Sum mod 2 of the values provided, if there is only one sum = G.creg[inst.clbits[0] + T.zero_clbit]
-            bool sum = std::accumulate(inst.clbits.begin(), inst.clbits.end(), false,
-                    [&G, &T](int acc, int clbit) { return acc ^ (G.creg[clbit + T.zero_clbit]); });
+            std::unordered_map<std::string, std::function<bool(bool, bool)>> ops{
+                {"and", [](bool a, bool b) { return a & b; }},
+                {"or",  [](bool a, bool b) { return a | b; }},
+                {"xor", [](bool a, bool b) { return a ^ b; }},
+                {"0and", [](bool a, bool b) { return !a & !b; }},
+                {"0or",  [](bool a, bool b) { return !a | !b; }},
+                {"0xor", [](bool a, bool b) { return !a ^ !b; }}
+            };
+            // Operates on the values provided, with the specified operation.
+            // If there is only one value, sum = G.creg[inst.clbits[0] + T.zero_clbit]
+            bool result = std::accumulate(inst.clbits.begin() + 1, inst.clbits.end(), 
+                           G.creg[inst.clbits[0] + T.zero_clbit],
+                           [&](bool acc, int clbit) { 
+                               return ops[inst.operation](acc, G.creg[clbit + T.zero_clbit]); 
+                           });
+            result = (static_cast<bool>(inst.condition)) ? result : !result;
 
-            if (static_cast<bool>(inst.condition) == sum) {
+            if (static_cast<bool>(inst.condition) == result) {
                 for(const auto& sub_inst: inst.instructions) {
                     apply_next_instr(T, sub_inst, {});
                 }

--- a/src/backends/simulators/AER/aer_adapters/aer_simulator_adapter.cpp
+++ b/src/backends/simulators/AER/aer_adapters/aer_simulator_adapter.cpp
@@ -684,7 +684,11 @@ std::unordered_map<std::string, std::string> execute_shot_(
         }
         case constants::CIF:
         {
-            if ((bool)inst.condition == G.creg[inst.clbits[0] + T.zero_clbit]) {
+            // Sum mod 2 of the values provided, if there is only one sum = G.creg[inst.clbits[0] + T.zero_clbit]
+            bool sum = std::accumulate(inst.clbits.begin(), inst.clbits.end(), false,
+                    [&G, &T](int acc, int clbit) { return acc ^ (G.creg[clbit + T.zero_clbit]); });
+
+            if (static_cast<bool>(inst.condition) == sum) {
                 for(const auto& sub_inst: inst.instructions) {
                     apply_next_instr(T, sub_inst, {});
                 }

--- a/src/backends/simulators/AER/aer_adapters/aer_simulator_adapter.cpp
+++ b/src/backends/simulators/AER/aer_adapters/aer_simulator_adapter.cpp
@@ -693,8 +693,8 @@ std::unordered_map<std::string, std::string> execute_shot_(
                 {"0xor", [](bool a, bool b) { return a ^ !b; }}
             };
             bool init = (static_cast<bool>(inst.condition)) ? G.creg[inst.clbits[0] + T.zero_clbit] : !G.creg[inst.clbits[0] + T.zero_clbit];
-            // Operates on the values provided, with the specified operation.
-            // If there is only one value, sum = G.creg[inst.clbits[0] + T.zero_clbit]
+            // Applies the specified operation to the sequence of bits provided
+            // If there is only one value, result = G.creg[inst.clbits[0] + T.zero_clbit] when checking inst.condition == result
             bool result = std::accumulate(inst.clbits.begin() + 1, inst.clbits.end(), 
                            init,
                            [&](bool acc, int clbit) { 

--- a/src/backends/simulators/AER/aer_adapters/aer_simulator_adapter.cpp
+++ b/src/backends/simulators/AER/aer_adapters/aer_simulator_adapter.cpp
@@ -688,14 +688,15 @@ std::unordered_map<std::string, std::string> execute_shot_(
                 {"and", [](bool a, bool b) { return a & b; }},
                 {"or",  [](bool a, bool b) { return a | b; }},
                 {"xor", [](bool a, bool b) { return a ^ b; }},
-                {"0and", [](bool a, bool b) { return !a & !b; }},
-                {"0or",  [](bool a, bool b) { return !a | !b; }},
-                {"0xor", [](bool a, bool b) { return !a ^ !b; }}
+                {"0and", [](bool a, bool b) { return a & !b; }},
+                {"0or",  [](bool a, bool b) { return a | !b; }},
+                {"0xor", [](bool a, bool b) { return a ^ !b; }}
             };
+            bool init = (static_cast<bool>(inst.condition)) ? G.creg[inst.clbits[0] + T.zero_clbit] : !G.creg[inst.clbits[0] + T.zero_clbit];
             // Operates on the values provided, with the specified operation.
             // If there is only one value, sum = G.creg[inst.clbits[0] + T.zero_clbit]
             bool result = std::accumulate(inst.clbits.begin() + 1, inst.clbits.end(), 
-                           G.creg[inst.clbits[0] + T.zero_clbit],
+                           init,
                            [&](bool acc, int clbit) { 
                                return ops[inst.operation](acc, G.creg[clbit + T.zero_clbit]); 
                            });

--- a/src/backends/simulators/AER/aer_adapters/aer_simulator_adapter.cpp
+++ b/src/backends/simulators/AER/aer_adapters/aer_simulator_adapter.cpp
@@ -689,7 +689,7 @@ std::unordered_map<std::string, std::string> execute_shot_(
             bool result = std::accumulate(inst.clbits.begin() + 1, inst.clbits.end(), 
                            init,
                            [&](bool acc, int clbit) { 
-                               return constants::boolean_ops[inst.operation](acc, G.creg[clbit + T.zero_clbit]); 
+                               return constants::cif_ops[inst.operation](acc, G.creg[clbit + T.zero_clbit]); 
                            });
             result = (static_cast<bool>(inst.condition)) ? result : !result;
 

--- a/src/backends/simulators/AER/aer_adapters/aer_simulator_adapter.cpp
+++ b/src/backends/simulators/AER/aer_adapters/aer_simulator_adapter.cpp
@@ -117,7 +117,6 @@ std::vector<int> find_my_communication_pairs(const GlobalState& G, const std::st
     return comm_pairs;
 }
 
-
 std::unordered_map<std::string, std::string> execute_shot_(
     AER::AerState* state, 
     std::vector<StructuredQuantumTask>& st_qtasks,
@@ -684,21 +683,13 @@ std::unordered_map<std::string, std::string> execute_shot_(
         }
         case constants::CIF:
         {
-            std::unordered_map<std::string, std::function<bool(bool, bool)>> ops{
-                {"and", [](bool a, bool b) { return a & b; }},
-                {"or",  [](bool a, bool b) { return a | b; }},
-                {"xor", [](bool a, bool b) { return a ^ b; }},
-                {"0and", [](bool a, bool b) { return a & !b; }},
-                {"0or",  [](bool a, bool b) { return a | !b; }},
-                {"0xor", [](bool a, bool b) { return a ^ !b; }}
-            };
             bool init = (static_cast<bool>(inst.condition)) ? G.creg[inst.clbits[0] + T.zero_clbit] : !G.creg[inst.clbits[0] + T.zero_clbit];
             // Applies the specified operation to the sequence of bits provided
             // If there is only one value, result = G.creg[inst.clbits[0] + T.zero_clbit] when checking inst.condition == result
             bool result = std::accumulate(inst.clbits.begin() + 1, inst.clbits.end(), 
                            init,
                            [&](bool acc, int clbit) { 
-                               return ops[inst.operation](acc, G.creg[clbit + T.zero_clbit]); 
+                               return constants::boolean_ops[inst.operation](acc, G.creg[clbit + T.zero_clbit]); 
                            });
             result = (static_cast<bool>(inst.condition)) ? result : !result;
 

--- a/src/backends/simulators/CUNQA/cunqa_adapters/cunqa_simulator_adapter.cpp
+++ b/src/backends/simulators/CUNQA/cunqa_adapters/cunqa_simulator_adapter.cpp
@@ -305,7 +305,11 @@ std::unordered_map<std::string, std::string> execute_shot_(
         }
         case constants::CIF:
         {
-            if ((bool)inst.condition == G.creg[inst.clbits[0] + T.zero_clbit]) {
+            // Sum mod 2 of the values provided, if there is only one sum = G.creg[inst.clbits[0] + T.zero_clbit]
+            bool sum = std::accumulate(inst.clbits.begin(), inst.clbits.end(), false,
+                    [&G, &T](int acc, int clbit) { return acc ^ (G.creg[clbit + T.zero_clbit]); });
+
+            if (static_cast<bool>(inst.condition) == sum) {
                 for(const auto& sub_inst: inst.instructions) {
                     apply_next_instr(T, sub_inst, {});
                 }

--- a/src/backends/simulators/CUNQA/cunqa_adapters/cunqa_simulator_adapter.cpp
+++ b/src/backends/simulators/CUNQA/cunqa_adapters/cunqa_simulator_adapter.cpp
@@ -305,21 +305,13 @@ std::unordered_map<std::string, std::string> execute_shot_(
         }
         case constants::CIF:
         {
-            std::unordered_map<std::string, std::function<bool(bool, bool)>> ops{
-                {"and", [](bool a, bool b) { return a & b; }},
-                {"or",  [](bool a, bool b) { return a | b; }},
-                {"xor", [](bool a, bool b) { return a ^ b; }},
-                {"0and", [](bool a, bool b) { return a & !b; }},
-                {"0or",  [](bool a, bool b) { return a | !b; }},
-                {"0xor", [](bool a, bool b) { return a ^ !b; }}
-            };
             bool init = (static_cast<bool>(inst.condition)) ? G.creg[inst.clbits[0] + T.zero_clbit] : !G.creg[inst.clbits[0] + T.zero_clbit];
             // Operates on the values provided, with the specified operation.
             // If there is only one value, sum = G.creg[inst.clbits[0] + T.zero_clbit]
             bool result = std::accumulate(inst.clbits.begin() + 1, inst.clbits.end(), 
                            init,
                            [&](bool acc, int clbit) { 
-                               return ops[inst.operation](acc, G.creg[clbit + T.zero_clbit]); 
+                               return constants::boolean_ops[inst.operation](acc, G.creg[clbit + T.zero_clbit]); 
                            });
             result = (static_cast<bool>(inst.condition)) ? result : !result;
 

--- a/src/backends/simulators/CUNQA/cunqa_adapters/cunqa_simulator_adapter.cpp
+++ b/src/backends/simulators/CUNQA/cunqa_adapters/cunqa_simulator_adapter.cpp
@@ -311,7 +311,7 @@ std::unordered_map<std::string, std::string> execute_shot_(
             bool result = std::accumulate(inst.clbits.begin() + 1, inst.clbits.end(), 
                            init,
                            [&](bool acc, int clbit) { 
-                               return constants::boolean_ops[inst.operation](acc, G.creg[clbit + T.zero_clbit]); 
+                               return constants::cif_ops[inst.operation](acc, G.creg[clbit + T.zero_clbit]); 
                            });
             result = (static_cast<bool>(inst.condition)) ? result : !result;
 

--- a/src/backends/simulators/CUNQA/cunqa_adapters/cunqa_simulator_adapter.cpp
+++ b/src/backends/simulators/CUNQA/cunqa_adapters/cunqa_simulator_adapter.cpp
@@ -305,11 +305,24 @@ std::unordered_map<std::string, std::string> execute_shot_(
         }
         case constants::CIF:
         {
-            // Sum mod 2 of the values provided, if there is only one sum = G.creg[inst.clbits[0] + T.zero_clbit]
-            bool sum = std::accumulate(inst.clbits.begin(), inst.clbits.end(), false,
-                    [&G, &T](int acc, int clbit) { return acc ^ (G.creg[clbit + T.zero_clbit]); });
+            std::unordered_map<std::string, std::function<bool(bool, bool)>> ops{
+                {"and", [](bool a, bool b) { return a & b; }},
+                {"or",  [](bool a, bool b) { return a | b; }},
+                {"xor", [](bool a, bool b) { return a ^ b; }},
+                {"0and", [](bool a, bool b) { return !a & !b; }},
+                {"0or",  [](bool a, bool b) { return !a | !b; }},
+                {"0xor", [](bool a, bool b) { return !a ^ !b; }}
+            };
+            // Operates on the values provided, with the specified operation.
+            // If there is only one value, sum = G.creg[inst.clbits[0] + T.zero_clbit]
+            bool result = std::accumulate(inst.clbits.begin() + 1, inst.clbits.end(), 
+                           G.creg[inst.clbits[0] + T.zero_clbit],
+                           [&](bool acc, int clbit) { 
+                               return ops[inst.operation](acc, G.creg[clbit + T.zero_clbit]); 
+                           });
+            result = (static_cast<bool>(inst.condition)) ? result : !result;
 
-            if (static_cast<bool>(inst.condition) == sum) {
+            if (static_cast<bool>(inst.condition) == result) {
                 for(const auto& sub_inst: inst.instructions) {
                     apply_next_instr(T, sub_inst, {});
                 }

--- a/src/backends/simulators/CUNQA/cunqa_adapters/cunqa_simulator_adapter.cpp
+++ b/src/backends/simulators/CUNQA/cunqa_adapters/cunqa_simulator_adapter.cpp
@@ -309,14 +309,15 @@ std::unordered_map<std::string, std::string> execute_shot_(
                 {"and", [](bool a, bool b) { return a & b; }},
                 {"or",  [](bool a, bool b) { return a | b; }},
                 {"xor", [](bool a, bool b) { return a ^ b; }},
-                {"0and", [](bool a, bool b) { return !a & !b; }},
-                {"0or",  [](bool a, bool b) { return !a | !b; }},
-                {"0xor", [](bool a, bool b) { return !a ^ !b; }}
+                {"0and", [](bool a, bool b) { return a & !b; }},
+                {"0or",  [](bool a, bool b) { return a | !b; }},
+                {"0xor", [](bool a, bool b) { return a ^ !b; }}
             };
+            bool init = (static_cast<bool>(inst.condition)) ? G.creg[inst.clbits[0] + T.zero_clbit] : !G.creg[inst.clbits[0] + T.zero_clbit];
             // Operates on the values provided, with the specified operation.
             // If there is only one value, sum = G.creg[inst.clbits[0] + T.zero_clbit]
             bool result = std::accumulate(inst.clbits.begin() + 1, inst.clbits.end(), 
-                           G.creg[inst.clbits[0] + T.zero_clbit],
+                           init,
                            [&](bool acc, int clbit) { 
                                return ops[inst.operation](acc, G.creg[clbit + T.zero_clbit]); 
                            });

--- a/src/backends/simulators/Maestro/maestro_adapters/maestro_simulator_adapter.cpp
+++ b/src/backends/simulators/Maestro/maestro_adapters/maestro_simulator_adapter.cpp
@@ -523,14 +523,15 @@ std::unordered_map<std::string, std::string> execute_shot_(
                 {"and", [](bool a, bool b) { return a & b; }},
                 {"or",  [](bool a, bool b) { return a | b; }},
                 {"xor", [](bool a, bool b) { return a ^ b; }},
-                {"0and", [](bool a, bool b) { return !a & !b; }},
-                {"0or",  [](bool a, bool b) { return !a | !b; }},
-                {"0xor", [](bool a, bool b) { return !a ^ !b; }}
+                {"0and", [](bool a, bool b) { return a & !b; }},
+                {"0or",  [](bool a, bool b) { return a | !b; }},
+                {"0xor", [](bool a, bool b) { return a ^ !b; }}
             };
+            bool init = (static_cast<bool>(inst.condition)) ? G.creg[inst.clbits[0] + T.zero_clbit] : !G.creg[inst.clbits[0] + T.zero_clbit];
             // Operates on the values provided, with the specified operation.
             // If there is only one value, sum = G.creg[inst.clbits[0] + T.zero_clbit]
             bool result = std::accumulate(inst.clbits.begin() + 1, inst.clbits.end(), 
-                           G.creg[inst.clbits[0] + T.zero_clbit],
+                           init,
                            [&](bool acc, int clbit) { 
                                return ops[inst.operation](acc, G.creg[clbit + T.zero_clbit]); 
                            });

--- a/src/backends/simulators/Maestro/maestro_adapters/maestro_simulator_adapter.cpp
+++ b/src/backends/simulators/Maestro/maestro_adapters/maestro_simulator_adapter.cpp
@@ -519,21 +519,13 @@ std::unordered_map<std::string, std::string> execute_shot_(
         }
         case constants::CIF:
         {
-            std::unordered_map<std::string, std::function<bool(bool, bool)>> ops{
-                {"and", [](bool a, bool b) { return a & b; }},
-                {"or",  [](bool a, bool b) { return a | b; }},
-                {"xor", [](bool a, bool b) { return a ^ b; }},
-                {"0and", [](bool a, bool b) { return a & !b; }},
-                {"0or",  [](bool a, bool b) { return a | !b; }},
-                {"0xor", [](bool a, bool b) { return a ^ !b; }}
-            };
             bool init = (static_cast<bool>(inst.condition)) ? G.creg[inst.clbits[0] + T.zero_clbit] : !G.creg[inst.clbits[0] + T.zero_clbit];
             // Operates on the values provided, with the specified operation.
             // If there is only one value, sum = G.creg[inst.clbits[0] + T.zero_clbit]
             bool result = std::accumulate(inst.clbits.begin() + 1, inst.clbits.end(), 
                            init,
                            [&](bool acc, int clbit) { 
-                               return ops[inst.operation](acc, G.creg[clbit + T.zero_clbit]); 
+                               return constants::boolean_ops[inst.operation](acc, G.creg[clbit + T.zero_clbit]); 
                            });
             result = (static_cast<bool>(inst.condition)) ? result : !result;
 

--- a/src/backends/simulators/Maestro/maestro_adapters/maestro_simulator_adapter.cpp
+++ b/src/backends/simulators/Maestro/maestro_adapters/maestro_simulator_adapter.cpp
@@ -525,7 +525,7 @@ std::unordered_map<std::string, std::string> execute_shot_(
             bool result = std::accumulate(inst.clbits.begin() + 1, inst.clbits.end(), 
                            init,
                            [&](bool acc, int clbit) { 
-                               return constants::boolean_ops[inst.operation](acc, G.creg[clbit + T.zero_clbit]); 
+                               return constants::cif_ops[inst.operation](acc, G.creg[clbit + T.zero_clbit]); 
                            });
             result = (static_cast<bool>(inst.condition)) ? result : !result;
 

--- a/src/backends/simulators/Maestro/maestro_adapters/maestro_simulator_adapter.cpp
+++ b/src/backends/simulators/Maestro/maestro_adapters/maestro_simulator_adapter.cpp
@@ -519,8 +519,11 @@ std::unordered_map<std::string, std::string> execute_shot_(
         }
         case constants::CIF:
         {
-            const auto& clbits = inst.clbits;
-            if ((bool)inst.condition == G.creg[inst.clbits[0] + T.zero_clbit]) {
+            // Sum mod 2 of the values provided, if there is only one sum = G.creg[inst.clbits[0] + T.zero_clbit]
+            bool sum = std::accumulate(inst.clbits.begin(), inst.clbits.end(), false,
+                    [&G, &T](int acc, int clbit) { return acc ^ (G.creg[clbit + T.zero_clbit]); });
+
+            if (static_cast<bool>(inst.condition) == sum) {
                 for(const auto& sub_inst: inst.instructions) {
                     apply_next_instr(T, sub_inst, {});
                 }

--- a/src/backends/simulators/Maestro/maestro_adapters/maestro_simulator_adapter.cpp
+++ b/src/backends/simulators/Maestro/maestro_adapters/maestro_simulator_adapter.cpp
@@ -519,11 +519,24 @@ std::unordered_map<std::string, std::string> execute_shot_(
         }
         case constants::CIF:
         {
-            // Sum mod 2 of the values provided, if there is only one sum = G.creg[inst.clbits[0] + T.zero_clbit]
-            bool sum = std::accumulate(inst.clbits.begin(), inst.clbits.end(), false,
-                    [&G, &T](int acc, int clbit) { return acc ^ (G.creg[clbit + T.zero_clbit]); });
+            std::unordered_map<std::string, std::function<bool(bool, bool)>> ops{
+                {"and", [](bool a, bool b) { return a & b; }},
+                {"or",  [](bool a, bool b) { return a | b; }},
+                {"xor", [](bool a, bool b) { return a ^ b; }},
+                {"0and", [](bool a, bool b) { return !a & !b; }},
+                {"0or",  [](bool a, bool b) { return !a | !b; }},
+                {"0xor", [](bool a, bool b) { return !a ^ !b; }}
+            };
+            // Operates on the values provided, with the specified operation.
+            // If there is only one value, sum = G.creg[inst.clbits[0] + T.zero_clbit]
+            bool result = std::accumulate(inst.clbits.begin() + 1, inst.clbits.end(), 
+                           G.creg[inst.clbits[0] + T.zero_clbit],
+                           [&](bool acc, int clbit) { 
+                               return ops[inst.operation](acc, G.creg[clbit + T.zero_clbit]); 
+                           });
+            result = (static_cast<bool>(inst.condition)) ? result : !result;
 
-            if (static_cast<bool>(inst.condition) == sum) {
+            if (static_cast<bool>(inst.condition) == result) {
                 for(const auto& sub_inst: inst.instructions) {
                     apply_next_instr(T, sub_inst, {});
                 }

--- a/src/backends/simulators/Munich/munich_adapters/munich_simulator_adapter.cpp
+++ b/src/backends/simulators/Munich/munich_adapters/munich_simulator_adapter.cpp
@@ -414,14 +414,15 @@ std::unordered_map<std::string, std::string> MunichSimulatorAdapter::execute_sho
                 {"and", [](bool a, bool b) { return a & b; }},
                 {"or",  [](bool a, bool b) { return a | b; }},
                 {"xor", [](bool a, bool b) { return a ^ b; }},
-                {"0and", [](bool a, bool b) { return !a & !b; }},
-                {"0or",  [](bool a, bool b) { return !a | !b; }},
-                {"0xor", [](bool a, bool b) { return !a ^ !b; }}
+                {"0and", [](bool a, bool b) { return a & !b; }},
+                {"0or",  [](bool a, bool b) { return a | !b; }},
+                {"0xor", [](bool a, bool b) { return a ^ !b; }}
             };
+            bool init = (static_cast<bool>(inst.condition)) ? G.creg[inst.clbits[0] + T.zero_clbit] : !G.creg[inst.clbits[0] + T.zero_clbit];
             // Operates on the values provided, with the specified operation.
             // If there is only one value, sum = G.creg[inst.clbits[0] + T.zero_clbit]
             bool result = std::accumulate(inst.clbits.begin() + 1, inst.clbits.end(), 
-                           G.creg[inst.clbits[0] + T.zero_clbit],
+                           init,
                            [&](bool acc, int clbit) { 
                                return ops[inst.operation](acc, G.creg[clbit + T.zero_clbit]); 
                            });

--- a/src/backends/simulators/Munich/munich_adapters/munich_simulator_adapter.cpp
+++ b/src/backends/simulators/Munich/munich_adapters/munich_simulator_adapter.cpp
@@ -410,7 +410,11 @@ std::unordered_map<std::string, std::string> MunichSimulatorAdapter::execute_sho
         }
         case constants::CIF:
         {
-            if ((bool)inst.condition == G.creg[inst.clbits[0] + T.zero_clbit]) {
+            // Sum mod 2 of the values provided, if there is only one sum = G.creg[inst.clbits[0] + T.zero_clbit]
+            bool sum = std::accumulate(inst.clbits.begin(), inst.clbits.end(), false,
+                    [&G, &T](int acc, int clbit) { return acc ^ (G.creg[clbit + T.zero_clbit]); });
+
+            if (static_cast<bool>(inst.condition) == sum) {
                 for(const auto& sub_inst: inst.instructions) {
                     apply_next_instr(T, sub_inst, {});
                 }

--- a/src/backends/simulators/Munich/munich_adapters/munich_simulator_adapter.cpp
+++ b/src/backends/simulators/Munich/munich_adapters/munich_simulator_adapter.cpp
@@ -416,7 +416,7 @@ std::unordered_map<std::string, std::string> MunichSimulatorAdapter::execute_sho
             bool result = std::accumulate(inst.clbits.begin() + 1, inst.clbits.end(), 
                            init,
                            [&](bool acc, int clbit) { 
-                               return constants::boolean_ops[inst.operation](acc, G.creg[clbit + T.zero_clbit]); 
+                               return constants::cif_ops[inst.operation](acc, G.creg[clbit + T.zero_clbit]); 
                            });
             result = (static_cast<bool>(inst.condition)) ? result : !result;
 

--- a/src/backends/simulators/Munich/munich_adapters/munich_simulator_adapter.cpp
+++ b/src/backends/simulators/Munich/munich_adapters/munich_simulator_adapter.cpp
@@ -410,21 +410,13 @@ std::unordered_map<std::string, std::string> MunichSimulatorAdapter::execute_sho
         }
         case constants::CIF:
         {
-            std::unordered_map<std::string, std::function<bool(bool, bool)>> ops{
-                {"and", [](bool a, bool b) { return a & b; }},
-                {"or",  [](bool a, bool b) { return a | b; }},
-                {"xor", [](bool a, bool b) { return a ^ b; }},
-                {"0and", [](bool a, bool b) { return a & !b; }},
-                {"0or",  [](bool a, bool b) { return a | !b; }},
-                {"0xor", [](bool a, bool b) { return a ^ !b; }}
-            };
             bool init = (static_cast<bool>(inst.condition)) ? G.creg[inst.clbits[0] + T.zero_clbit] : !G.creg[inst.clbits[0] + T.zero_clbit];
             // Operates on the values provided, with the specified operation.
             // If there is only one value, sum = G.creg[inst.clbits[0] + T.zero_clbit]
             bool result = std::accumulate(inst.clbits.begin() + 1, inst.clbits.end(), 
                            init,
                            [&](bool acc, int clbit) { 
-                               return ops[inst.operation](acc, G.creg[clbit + T.zero_clbit]); 
+                               return constants::boolean_ops[inst.operation](acc, G.creg[clbit + T.zero_clbit]); 
                            });
             result = (static_cast<bool>(inst.condition)) ? result : !result;
 

--- a/src/backends/simulators/Munich/munich_adapters/munich_simulator_adapter.cpp
+++ b/src/backends/simulators/Munich/munich_adapters/munich_simulator_adapter.cpp
@@ -410,11 +410,24 @@ std::unordered_map<std::string, std::string> MunichSimulatorAdapter::execute_sho
         }
         case constants::CIF:
         {
-            // Sum mod 2 of the values provided, if there is only one sum = G.creg[inst.clbits[0] + T.zero_clbit]
-            bool sum = std::accumulate(inst.clbits.begin(), inst.clbits.end(), false,
-                    [&G, &T](int acc, int clbit) { return acc ^ (G.creg[clbit + T.zero_clbit]); });
+            std::unordered_map<std::string, std::function<bool(bool, bool)>> ops{
+                {"and", [](bool a, bool b) { return a & b; }},
+                {"or",  [](bool a, bool b) { return a | b; }},
+                {"xor", [](bool a, bool b) { return a ^ b; }},
+                {"0and", [](bool a, bool b) { return !a & !b; }},
+                {"0or",  [](bool a, bool b) { return !a | !b; }},
+                {"0xor", [](bool a, bool b) { return !a ^ !b; }}
+            };
+            // Operates on the values provided, with the specified operation.
+            // If there is only one value, sum = G.creg[inst.clbits[0] + T.zero_clbit]
+            bool result = std::accumulate(inst.clbits.begin() + 1, inst.clbits.end(), 
+                           G.creg[inst.clbits[0] + T.zero_clbit],
+                           [&](bool acc, int clbit) { 
+                               return ops[inst.operation](acc, G.creg[clbit + T.zero_clbit]); 
+                           });
+            result = (static_cast<bool>(inst.condition)) ? result : !result;
 
-            if (static_cast<bool>(inst.condition) == sum) {
+            if (static_cast<bool>(inst.condition) == result) {
                 for(const auto& sub_inst: inst.instructions) {
                     apply_next_instr(T, sub_inst, {});
                 }

--- a/src/backends/simulators/Qsim/qsim_adapters/qsim_simulator_adapter.cpp
+++ b/src/backends/simulators/Qsim/qsim_adapters/qsim_simulator_adapter.cpp
@@ -500,14 +500,15 @@ std::unordered_map<std::string, std::string> execute_shot_(
                 {"and", [](bool a, bool b) { return a & b; }},
                 {"or",  [](bool a, bool b) { return a | b; }},
                 {"xor", [](bool a, bool b) { return a ^ b; }},
-                {"0and", [](bool a, bool b) { return !a & !b; }},
-                {"0or",  [](bool a, bool b) { return !a | !b; }},
-                {"0xor", [](bool a, bool b) { return !a ^ !b; }}
+                {"0and", [](bool a, bool b) { return a & !b; }},
+                {"0or",  [](bool a, bool b) { return a | !b; }},
+                {"0xor", [](bool a, bool b) { return a ^ !b; }}
             };
+            bool init = (static_cast<bool>(inst.condition)) ? G.creg[inst.clbits[0] + T.zero_clbit] : !G.creg[inst.clbits[0] + T.zero_clbit];
             // Operates on the values provided, with the specified operation.
             // If there is only one value, sum = G.creg[inst.clbits[0] + T.zero_clbit]
             bool result = std::accumulate(inst.clbits.begin() + 1, inst.clbits.end(), 
-                           G.creg[inst.clbits[0] + T.zero_clbit],
+                           init,
                            [&](bool acc, int clbit) { 
                                return ops[inst.operation](acc, G.creg[clbit + T.zero_clbit]); 
                            });

--- a/src/backends/simulators/Qsim/qsim_adapters/qsim_simulator_adapter.cpp
+++ b/src/backends/simulators/Qsim/qsim_adapters/qsim_simulator_adapter.cpp
@@ -496,7 +496,11 @@ std::unordered_map<std::string, std::string> execute_shot_(
         }
         case constants::CIF:
         {
-            if ((bool)inst.condition == G.creg[inst.clbits[0] + T.zero_clbit]) {
+            // Sum mod 2 of the values provided, if there is only one sum = G.creg[inst.clbits[0] + T.zero_clbit]
+            bool sum = std::accumulate(inst.clbits.begin(), inst.clbits.end(), false,
+                    [&G, &T](int acc, int clbit) { return acc ^ (G.creg[clbit + T.zero_clbit]); });
+
+            if (static_cast<bool>(inst.condition) == sum) {
                 for(const auto& sub_inst: inst.instructions) {
                     apply_next_instr(T, sub_inst, {});
                 }

--- a/src/backends/simulators/Qsim/qsim_adapters/qsim_simulator_adapter.cpp
+++ b/src/backends/simulators/Qsim/qsim_adapters/qsim_simulator_adapter.cpp
@@ -502,7 +502,7 @@ std::unordered_map<std::string, std::string> execute_shot_(
             bool result = std::accumulate(inst.clbits.begin() + 1, inst.clbits.end(), 
                            init,
                            [&](bool acc, int clbit) { 
-                               return constants::boolean_ops[inst.operation](acc, G.creg[clbit + T.zero_clbit]); 
+                               return constants::cif_ops[inst.operation](acc, G.creg[clbit + T.zero_clbit]); 
                            });
             result = (static_cast<bool>(inst.condition)) ? result : !result;
 

--- a/src/backends/simulators/Qsim/qsim_adapters/qsim_simulator_adapter.cpp
+++ b/src/backends/simulators/Qsim/qsim_adapters/qsim_simulator_adapter.cpp
@@ -496,11 +496,24 @@ std::unordered_map<std::string, std::string> execute_shot_(
         }
         case constants::CIF:
         {
-            // Sum mod 2 of the values provided, if there is only one sum = G.creg[inst.clbits[0] + T.zero_clbit]
-            bool sum = std::accumulate(inst.clbits.begin(), inst.clbits.end(), false,
-                    [&G, &T](int acc, int clbit) { return acc ^ (G.creg[clbit + T.zero_clbit]); });
+            std::unordered_map<std::string, std::function<bool(bool, bool)>> ops{
+                {"and", [](bool a, bool b) { return a & b; }},
+                {"or",  [](bool a, bool b) { return a | b; }},
+                {"xor", [](bool a, bool b) { return a ^ b; }},
+                {"0and", [](bool a, bool b) { return !a & !b; }},
+                {"0or",  [](bool a, bool b) { return !a | !b; }},
+                {"0xor", [](bool a, bool b) { return !a ^ !b; }}
+            };
+            // Operates on the values provided, with the specified operation.
+            // If there is only one value, sum = G.creg[inst.clbits[0] + T.zero_clbit]
+            bool result = std::accumulate(inst.clbits.begin() + 1, inst.clbits.end(), 
+                           G.creg[inst.clbits[0] + T.zero_clbit],
+                           [&](bool acc, int clbit) { 
+                               return ops[inst.operation](acc, G.creg[clbit + T.zero_clbit]); 
+                           });
+            result = (static_cast<bool>(inst.condition)) ? result : !result;
 
-            if (static_cast<bool>(inst.condition) == sum) {
+            if (static_cast<bool>(inst.condition) == result) {
                 for(const auto& sub_inst: inst.instructions) {
                     apply_next_instr(T, sub_inst, {});
                 }

--- a/src/backends/simulators/Qsim/qsim_adapters/qsim_simulator_adapter.cpp
+++ b/src/backends/simulators/Qsim/qsim_adapters/qsim_simulator_adapter.cpp
@@ -496,21 +496,13 @@ std::unordered_map<std::string, std::string> execute_shot_(
         }
         case constants::CIF:
         {
-            std::unordered_map<std::string, std::function<bool(bool, bool)>> ops{
-                {"and", [](bool a, bool b) { return a & b; }},
-                {"or",  [](bool a, bool b) { return a | b; }},
-                {"xor", [](bool a, bool b) { return a ^ b; }},
-                {"0and", [](bool a, bool b) { return a & !b; }},
-                {"0or",  [](bool a, bool b) { return a | !b; }},
-                {"0xor", [](bool a, bool b) { return a ^ !b; }}
-            };
             bool init = (static_cast<bool>(inst.condition)) ? G.creg[inst.clbits[0] + T.zero_clbit] : !G.creg[inst.clbits[0] + T.zero_clbit];
             // Operates on the values provided, with the specified operation.
             // If there is only one value, sum = G.creg[inst.clbits[0] + T.zero_clbit]
             bool result = std::accumulate(inst.clbits.begin() + 1, inst.clbits.end(), 
                            init,
                            [&](bool acc, int clbit) { 
-                               return ops[inst.operation](acc, G.creg[clbit + T.zero_clbit]); 
+                               return constants::boolean_ops[inst.operation](acc, G.creg[clbit + T.zero_clbit]); 
                            });
             result = (static_cast<bool>(inst.condition)) ? result : !result;
 

--- a/src/backends/simulators/QuEST/quest_adapters/quest_simulator_adapter.cpp
+++ b/src/backends/simulators/QuEST/quest_adapters/quest_simulator_adapter.cpp
@@ -1035,8 +1035,12 @@ std::unordered_map<std::string, std::string> execute_shot_(
             break;
         }
         case constants::CIF:
-        {
-            if ((bool)inst.condition == G.creg[inst.clbits[0] + T.zero_clbit]) {
+        {   
+            // Sum mod 2 of the values provided, if there is only one sum = G.creg[inst.clbits[0] + T.zero_clbit]
+            bool sum = std::accumulate(inst.clbits.begin(), inst.clbits.end(), false,
+                    [&G, &T](int acc, int clbit) { return acc ^ (G.creg[clbit + T.zero_clbit]); });
+
+            if (static_cast<bool>(inst.condition) == sum) {
                 for(const auto& sub_inst: inst.instructions) {
                     apply_next_instr(T, sub_inst, {});
                 }

--- a/src/backends/simulators/QuEST/quest_adapters/quest_simulator_adapter.cpp
+++ b/src/backends/simulators/QuEST/quest_adapters/quest_simulator_adapter.cpp
@@ -1042,7 +1042,7 @@ std::unordered_map<std::string, std::string> execute_shot_(
             bool result = std::accumulate(inst.clbits.begin() + 1, inst.clbits.end(), 
                            init,
                            [&](bool acc, int clbit) { 
-                               return constants::boolean_ops[inst.operation](acc, G.creg[clbit + T.zero_clbit]); 
+                               return constants::cif_ops[inst.operation](acc, G.creg[clbit + T.zero_clbit]); 
                            });
             result = (static_cast<bool>(inst.condition)) ? result : !result;
 

--- a/src/backends/simulators/QuEST/quest_adapters/quest_simulator_adapter.cpp
+++ b/src/backends/simulators/QuEST/quest_adapters/quest_simulator_adapter.cpp
@@ -1036,11 +1036,24 @@ std::unordered_map<std::string, std::string> execute_shot_(
         }
         case constants::CIF:
         {   
-            // Sum mod 2 of the values provided, if there is only one sum = G.creg[inst.clbits[0] + T.zero_clbit]
-            bool sum = std::accumulate(inst.clbits.begin(), inst.clbits.end(), false,
-                    [&G, &T](int acc, int clbit) { return acc ^ (G.creg[clbit + T.zero_clbit]); });
+            std::unordered_map<std::string, std::function<bool(bool, bool)>> ops{
+                {"and", [](bool a, bool b) { return a & b; }},
+                {"or",  [](bool a, bool b) { return a | b; }},
+                {"xor", [](bool a, bool b) { return a ^ b; }},
+                {"0and", [](bool a, bool b) { return !a & !b; }},
+                {"0or",  [](bool a, bool b) { return !a | !b; }},
+                {"0xor", [](bool a, bool b) { return !a ^ !b; }}
+            };
+            // Operates on the values provided, with the specified operation.
+            // If there is only one value, sum = G.creg[inst.clbits[0] + T.zero_clbit]
+            bool result = std::accumulate(inst.clbits.begin() + 1, inst.clbits.end(), 
+                           G.creg[inst.clbits[0] + T.zero_clbit],
+                           [&](bool acc, int clbit) { 
+                               return ops[inst.operation](acc, G.creg[clbit + T.zero_clbit]); 
+                           });
+            result = (static_cast<bool>(inst.condition)) ? result : !result;
 
-            if (static_cast<bool>(inst.condition) == sum) {
+            if (static_cast<bool>(inst.condition) == result) {
                 for(const auto& sub_inst: inst.instructions) {
                     apply_next_instr(T, sub_inst, {});
                 }

--- a/src/backends/simulators/QuEST/quest_adapters/quest_simulator_adapter.cpp
+++ b/src/backends/simulators/QuEST/quest_adapters/quest_simulator_adapter.cpp
@@ -1040,14 +1040,15 @@ std::unordered_map<std::string, std::string> execute_shot_(
                 {"and", [](bool a, bool b) { return a & b; }},
                 {"or",  [](bool a, bool b) { return a | b; }},
                 {"xor", [](bool a, bool b) { return a ^ b; }},
-                {"0and", [](bool a, bool b) { return !a & !b; }},
-                {"0or",  [](bool a, bool b) { return !a | !b; }},
-                {"0xor", [](bool a, bool b) { return !a ^ !b; }}
+                {"0and", [](bool a, bool b) { return a & !b; }},
+                {"0or",  [](bool a, bool b) { return a | !b; }},
+                {"0xor", [](bool a, bool b) { return a ^ !b; }}
             };
+            bool init = (static_cast<bool>(inst.condition)) ? G.creg[inst.clbits[0] + T.zero_clbit] : !G.creg[inst.clbits[0] + T.zero_clbit];
             // Operates on the values provided, with the specified operation.
             // If there is only one value, sum = G.creg[inst.clbits[0] + T.zero_clbit]
             bool result = std::accumulate(inst.clbits.begin() + 1, inst.clbits.end(), 
-                           G.creg[inst.clbits[0] + T.zero_clbit],
+                           init,
                            [&](bool acc, int clbit) { 
                                return ops[inst.operation](acc, G.creg[clbit + T.zero_clbit]); 
                            });

--- a/src/backends/simulators/QuEST/quest_adapters/quest_simulator_adapter.cpp
+++ b/src/backends/simulators/QuEST/quest_adapters/quest_simulator_adapter.cpp
@@ -1036,21 +1036,13 @@ std::unordered_map<std::string, std::string> execute_shot_(
         }
         case constants::CIF:
         {   
-            std::unordered_map<std::string, std::function<bool(bool, bool)>> ops{
-                {"and", [](bool a, bool b) { return a & b; }},
-                {"or",  [](bool a, bool b) { return a | b; }},
-                {"xor", [](bool a, bool b) { return a ^ b; }},
-                {"0and", [](bool a, bool b) { return a & !b; }},
-                {"0or",  [](bool a, bool b) { return a | !b; }},
-                {"0xor", [](bool a, bool b) { return a ^ !b; }}
-            };
             bool init = (static_cast<bool>(inst.condition)) ? G.creg[inst.clbits[0] + T.zero_clbit] : !G.creg[inst.clbits[0] + T.zero_clbit];
             // Operates on the values provided, with the specified operation.
             // If there is only one value, sum = G.creg[inst.clbits[0] + T.zero_clbit]
             bool result = std::accumulate(inst.clbits.begin() + 1, inst.clbits.end(), 
                            init,
                            [&](bool acc, int clbit) { 
-                               return ops[inst.operation](acc, G.creg[clbit + T.zero_clbit]); 
+                               return constants::boolean_ops[inst.operation](acc, G.creg[clbit + T.zero_clbit]); 
                            });
             result = (static_cast<bool>(inst.condition)) ? result : !result;
 

--- a/src/backends/simulators/Qulacs/qulacs_adapters/qulacs_simulator_adapter.cpp
+++ b/src/backends/simulators/Qulacs/qulacs_adapters/qulacs_simulator_adapter.cpp
@@ -606,14 +606,15 @@ std::unordered_map<std::string, std::string> execute_shot_(
                 {"and", [](bool a, bool b) { return a & b; }},
                 {"or",  [](bool a, bool b) { return a | b; }},
                 {"xor", [](bool a, bool b) { return a ^ b; }},
-                {"0and", [](bool a, bool b) { return !a & !b; }},
-                {"0or",  [](bool a, bool b) { return !a | !b; }},
-                {"0xor", [](bool a, bool b) { return !a ^ !b; }}
+                {"0and", [](bool a, bool b) { return a & !b; }},
+                {"0or",  [](bool a, bool b) { return a | !b; }},
+                {"0xor", [](bool a, bool b) { return a ^ !b; }}
             };
+            bool init = (static_cast<bool>(inst.condition)) ? G.creg[inst.clbits[0] + T.zero_clbit] : !G.creg[inst.clbits[0] + T.zero_clbit];
             // Operates on the values provided, with the specified operation.
             // If there is only one value, sum = G.creg[inst.clbits[0] + T.zero_clbit]
             bool result = std::accumulate(inst.clbits.begin() + 1, inst.clbits.end(), 
-                           G.creg[inst.clbits[0] + T.zero_clbit],
+                           init,
                            [&](bool acc, int clbit) { 
                                return ops[inst.operation](acc, G.creg[clbit + T.zero_clbit]); 
                            });

--- a/src/backends/simulators/Qulacs/qulacs_adapters/qulacs_simulator_adapter.cpp
+++ b/src/backends/simulators/Qulacs/qulacs_adapters/qulacs_simulator_adapter.cpp
@@ -608,7 +608,7 @@ std::unordered_map<std::string, std::string> execute_shot_(
             bool result = std::accumulate(inst.clbits.begin() + 1, inst.clbits.end(), 
                            init,
                            [&](bool acc, int clbit) { 
-                               return constants::boolean_ops[inst.operation](acc, G.creg[clbit + T.zero_clbit]); 
+                               return constants::cif_ops[inst.operation](acc, G.creg[clbit + T.zero_clbit]); 
                            });
             result = (static_cast<bool>(inst.condition)) ? result : !result;
 

--- a/src/backends/simulators/Qulacs/qulacs_adapters/qulacs_simulator_adapter.cpp
+++ b/src/backends/simulators/Qulacs/qulacs_adapters/qulacs_simulator_adapter.cpp
@@ -602,21 +602,13 @@ std::unordered_map<std::string, std::string> execute_shot_(
         }
         case constants::CIF:
         {   
-            std::unordered_map<std::string, std::function<bool(bool, bool)>> ops{
-                {"and", [](bool a, bool b) { return a & b; }},
-                {"or",  [](bool a, bool b) { return a | b; }},
-                {"xor", [](bool a, bool b) { return a ^ b; }},
-                {"0and", [](bool a, bool b) { return a & !b; }},
-                {"0or",  [](bool a, bool b) { return a | !b; }},
-                {"0xor", [](bool a, bool b) { return a ^ !b; }}
-            };
             bool init = (static_cast<bool>(inst.condition)) ? G.creg[inst.clbits[0] + T.zero_clbit] : !G.creg[inst.clbits[0] + T.zero_clbit];
             // Operates on the values provided, with the specified operation.
             // If there is only one value, sum = G.creg[inst.clbits[0] + T.zero_clbit]
             bool result = std::accumulate(inst.clbits.begin() + 1, inst.clbits.end(), 
                            init,
                            [&](bool acc, int clbit) { 
-                               return ops[inst.operation](acc, G.creg[clbit + T.zero_clbit]); 
+                               return constants::boolean_ops[inst.operation](acc, G.creg[clbit + T.zero_clbit]); 
                            });
             result = (static_cast<bool>(inst.condition)) ? result : !result;
 

--- a/src/backends/simulators/Qulacs/qulacs_adapters/qulacs_simulator_adapter.cpp
+++ b/src/backends/simulators/Qulacs/qulacs_adapters/qulacs_simulator_adapter.cpp
@@ -601,8 +601,25 @@ std::unordered_map<std::string, std::string> execute_shot_(
             break;
         }
         case constants::CIF:
-        {
-            if ((bool)inst.condition == G.creg[inst.clbits[0] + T.zero_clbit]) {
+        {   
+            std::unordered_map<std::string, std::function<bool(bool, bool)>> ops{
+                {"and", [](bool a, bool b) { return a & b; }},
+                {"or",  [](bool a, bool b) { return a | b; }},
+                {"xor", [](bool a, bool b) { return a ^ b; }},
+                {"0and", [](bool a, bool b) { return !a & !b; }},
+                {"0or",  [](bool a, bool b) { return !a | !b; }},
+                {"0xor", [](bool a, bool b) { return !a ^ !b; }}
+            };
+            // Operates on the values provided, with the specified operation.
+            // If there is only one value, sum = G.creg[inst.clbits[0] + T.zero_clbit]
+            bool result = std::accumulate(inst.clbits.begin() + 1, inst.clbits.end(), 
+                           G.creg[inst.clbits[0] + T.zero_clbit],
+                           [&](bool acc, int clbit) { 
+                               return ops[inst.operation](acc, G.creg[clbit + T.zero_clbit]); 
+                           });
+            result = (static_cast<bool>(inst.condition)) ? result : !result;
+
+            if (static_cast<bool>(inst.condition) == result) {
                 for(const auto& sub_inst: inst.instructions) {
                     apply_next_instr(T, sub_inst, {});
                 }

--- a/src/utils/constants.hpp.in
+++ b/src/utils/constants.hpp.in
@@ -67,6 +67,7 @@ struct CUNQAInstruction {
   std::vector<unsigned int> block_size = {};
   std::vector<unsigned int> pauli_id_list = {};
   std::string paulistr{};
+  std::string operation{};
   int seed = 0;
   int condition = 1;
   int num_controls = 0;
@@ -833,6 +834,7 @@ inline std::vector<CUNQAInstruction> from_json_instructions_to_cunqainstructions
                 .name = instruction_name,
                 .clbits = instruction.at("clbits").get<std::vector<int>>(), 
                 .instructions = from_json_instructions_to_cunqainstructions(instruction.at("instructions").get<cunqa::JSON>()),
+                .operation = instruction.at("operation").get<std::string>(),
                 .condition = instruction.at("condition").get<int>()
             };
             break;

--- a/src/utils/constants.hpp.in
+++ b/src/utils/constants.hpp.in
@@ -52,13 +52,13 @@ using CUNQARow = std::vector<CUNQAComplex>;
 using CUNQAMatrix = std::vector<CUNQARow>;
 using CUNQAComplexVector = std::vector<std::complex<double>>;
 
-inline std::unordered_map<std::string, std::function<bool(bool, bool)>> boolean_ops{
+inline std::unordered_map<std::string, std::function<bool(bool, bool)>> cif_ops{
     {"and",  [](bool a, bool b) { return a & b; }},
     {"or",   [](bool a, bool b) { return a | b; }},
     {"xor",  [](bool a, bool b) { return a ^ b; }},
-    {"nand", [](bool a, bool b) { return a & !b; }},
-    {"nor",  [](bool a, bool b) { return a | !b; }},
-    {"nxor", [](bool a, bool b) { return a ^ !b; }}
+    {"andn", [](bool a, bool b) { return a & !b; }},
+    {"orn",  [](bool a, bool b) { return a | !b; }},
+    {"xorn", [](bool a, bool b) { return a ^ !b; }}
 };
 
 struct CUNQAInstruction {

--- a/src/utils/constants.hpp.in
+++ b/src/utils/constants.hpp.in
@@ -52,6 +52,15 @@ using CUNQARow = std::vector<CUNQAComplex>;
 using CUNQAMatrix = std::vector<CUNQARow>;
 using CUNQAComplexVector = std::vector<std::complex<double>>;
 
+inline std::unordered_map<std::string, std::function<bool(bool, bool)>> boolean_ops{
+    {"and",  [](bool a, bool b) { return a & b; }},
+    {"or",   [](bool a, bool b) { return a | b; }},
+    {"xor",  [](bool a, bool b) { return a ^ b; }},
+    {"nand", [](bool a, bool b) { return a & !b; }},
+    {"nor",  [](bool a, bool b) { return a | !b; }},
+    {"nxor", [](bool a, bool b) { return a ^ !b; }}
+};
+
 struct CUNQAInstruction {
   std::string name;
   std::vector<int> qubits = {};
@@ -66,8 +75,8 @@ struct CUNQAInstruction {
   std::vector<int> r_clbits = {};
   std::vector<unsigned int> block_size = {};
   std::vector<unsigned int> pauli_id_list = {};
-  std::string paulistr{};
-  std::string operation{};
+  std::string paulistr;
+  std::string operation;
   int seed = 0;
   int condition = 1;
   int num_controls = 0;


### PR DESCRIPTION
cif with multiple clbits takes sum mod 2 of the clbits as value to match to condition. The multiple clbits are provided in python in a list as follows 

```python
qc = CunqaCircuit(3, 3)
qc.x(0)
qc.x(1)
qc.measure(0, 0)
qc.measure(1, 1)

with qc.cif([0,1]) as cgates:
     cgates.x(2)
```
Returning `{'011': 1024}` in this case as 1+1 (mod 2) ≡ 0 (mod 2), so the xgate on qubit 2 is not applied.