### PR TITLE
Managed qiskit dependency in ir.py and qpu.py.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,14 +53,17 @@ jobs:
             pass
           PY
       - name: Copy constants.py.in into constants.py
-        run:
+        shell: bash
+        run: |
           cp cunqa/constants.py.in cunqa/constants.py
           sed -i 's/CUNQA_USE_QISKIT_PY = @CUNQA_USE_QISKIT_PY@/CUNQA_USE_QISKIT_PY = True/' cunqa/constants.py
       - name: Install Python deps
+        shell: bash
         run: |
           python -m pip install --upgrade pip
           pip install qiskit==1.2.4 pytest pyzmq==25.* qiskit-aer psutil
 
       - name: Run tests
+        shell: bash
         run: |
           pytest -q tests/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,6 +55,7 @@ jobs:
       - name: Copy constants.py.in into constants.py
         run:
           cp cunqa/constants.py.in cunqa/constants.py
+          sed -i 's/CUNQA_USE_QISKIT_PY = @CUNQA_USE_QISKIT_PY@/CUNQA_USE_QISKIT_PY = True/' cunqa/constants.py
       - name: Install Python deps
         run: |
           python -m pip install --upgrade pip

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,16 @@ if(NOT SYSTEM_NAME OR NOT (SYSTEM_NAME STREQUAL "QMIO" OR SYSTEM_NAME STREQUAL "
     set(SYSTEM_NAME "EXTERNAL_CLUSTER")
 endif()
 
+# Enable or disable Qiskit dependency. Enabled by default
+option(CUNQA_USE_QISKIT "Enable Qiskit support in CUNQA" ON)
+if(CUNQA_USE_QISKIT)
+  message(STATUS "Enabled Qiskit support in CUNQA")
+  set(CUNQA_USE_QISKIT_PY "True")
+else()
+  message(STATUS "Disabled Qiskit support in CUNQA")
+  set(CUNQA_USE_QISKIT_PY "False")
+endif()
+
 if(${SYSTEM_NAME} STREQUAL "QMIO")
   set(pybind11_DIR "/opt/cesga/qmio/hpc/software/Compiler/gcccore/12.3.0/pybind11/2.13.6-python-3.11.9/lib64/python3.11/site-packages/pybind11/share/cmake/pybind11/")
   find_package(Python 3.9.9 COMPONENTS Interpreter Development)

--- a/configure.sh
+++ b/configure.sh
@@ -2,7 +2,7 @@
 
 if [ $LMOD_SYSTEM_NAME == "QMIO" ]; then
     # Execution for QMIO
-    ml load qmio/hpc gcc/12.3.0 hpcx-ompi flexiblas/3.3.0 boost cmake/3.27.6 gcccore/12.3.0 eigen/5.0.0 ninja/1.9.0 nlohmann_json/3.12.0 pybind11/2.13.6-python-3.11.9 qiskit/1.2.4-python-3.11.9
+    ml load qmio/hpc gcc/12.3.0 hpcx-ompi flexiblas/3.3.0 boost cmake/3.27.6 gcccore/12.3.0 eigen/5.0.0 ninja/1.9.0 nlohmann_json/3.12.0 cython/3.0.9-python-3.11.9 pybind11/2.13.6-python-3.11.9 qiskit/1.2.4-python-3.11.9
     conda deactivate
 elif [ $LMOD_SYSTEM_NAME == "FT3" ]; then
     # Execution for FT3 

--- a/cunqa/circuit/ir.py
+++ b/cunqa/circuit/ir.py
@@ -2,10 +2,7 @@ from __future__ import annotations
 from functools import singledispatch
 import copy
 
-from qiskit import QuantumCircuit
-from qiskit.circuit import Parameter, ParameterExpression
-
-
+from cunqa.constants import CUNQA_USE_QISKIT_PY
 from cunqa.circuit import CunqaCircuit
 from cunqa.utils import generate_id
 from cunqa.logger import logger
@@ -36,147 +33,153 @@ def _(c: dict) -> dict:
     logger.warning("Circuit is already in IR format, returning it as is.")
     return c
 
-@to_ir.register
-def _(c: QuantumCircuit) -> dict:
-    """
-    Transforms a `qiskit.QuantumCircuit` to json `dict`.
 
-    Args:
-        c (qiskit.QuantumCircuit): circuit to transform to json.
+if CUNQA_USE_QISKIT_PY:
 
-    Return:
-        Json dict with the circuit information.
-    """
-    quantum_registers = {}
-    qinit = 0
-    for qr in c.qregs:
-        quantum_registers[qr.name] = list(range(qinit, qinit + qr.size))
-        qinit += qr.size
+    from qiskit import QuantumCircuit
+    from qiskit.circuit import Parameter
 
-    classical_registers = {}
-    cinit = 0
-    for cr in c.cregs:
-        classical_registers[cr.name] = list(range(cinit, cinit + cr.size))
-        cinit += cr.size
-    
-    json_data = {
-        "id": "QuantumCircuit_" + generate_id(),
-        "is_dynamic": False,
-        "instructions":[],
-        "sending_to":[],
-        "num_qubits":sum([q.size for q in c.qregs]),
-        "num_clbits": sum([c.size for c in c.cregs]),
-        "quantum_registers": quantum_registers,
-        "classical_registers": classical_registers, 
-        "params":[],
-        "component_comms": {}
-    }
+    @to_ir.register
+    def _(c: QuantumCircuit) -> dict:
+        """
+        Transforms a `qiskit.QuantumCircuit` to json `dict`.
 
-    for instruction in c.data:
-        if instruction.operation.name not in SUPPORTED_QISKIT_OPERATIONS:
-            raise ValueError(f"Instruction {instruction.operation.name} not supported for conversion.")
+        Args:
+            c (qiskit.QuantumCircuit): circuit to transform to json.
 
-        qreg = [r._register.name for r in instruction.qubits]
-        qubit = [q._index for q in instruction.qubits]
+        Return:
+            Json dict with the circuit information.
+        """
+        quantum_registers = {}
+        qinit = 0
+        for qr in c.qregs:
+            quantum_registers[qr.name] = list(range(qinit, qinit + qr.size))
+            qinit += qr.size
+
+        classical_registers = {}
+        cinit = 0
+        for cr in c.cregs:
+            classical_registers[cr.name] = list(range(cinit, cinit + cr.size))
+            cinit += cr.size
         
-        clreg = [r._register.name for r in instruction.clbits]
-        bit = [b._index for b in instruction.clbits]
+        json_data = {
+            "id": "QuantumCircuit_" + generate_id(),
+            "is_dynamic": False,
+            "instructions":[],
+            "sending_to":[],
+            "num_qubits":sum([q.size for q in c.qregs]),
+            "num_clbits": sum([c.size for c in c.cregs]),
+            "quantum_registers": quantum_registers,
+            "classical_registers": classical_registers, 
+            "params":[],
+            "component_comms": {}
+        }
 
-        if instruction.operation.name == "barrier":
-            pass
+        for instruction in c.data:
+            if instruction.operation.name not in SUPPORTED_QISKIT_OPERATIONS:
+                raise ValueError(f"Instruction {instruction.operation.name} not supported for conversion.")
 
-        elif instruction.operation.name == "measure":
-            json_data["instructions"].append({
+            qreg = [r._register.name for r in instruction.qubits]
+            qubit = [q._index for q in instruction.qubits]
+            
+            clreg = [r._register.name for r in instruction.clbits]
+            bit = [b._index for b in instruction.clbits]
+
+            if instruction.operation.name == "barrier":
+                pass
+
+            elif instruction.operation.name == "measure":
+                json_data["instructions"].append({
+                    "name":instruction.operation.name,
+                    "qubits":[quantum_registers[k][q] for k,q in zip(qreg, qubit)],
+                    "clbits":[classical_registers[k][b] for k,b in zip(clreg, bit)]
+                })
+
+            elif instruction.operation.name == "unitary":
+                json_data["instructions"].append({
+                    "name":instruction.operation.name, 
+                    "qubits":[quantum_registers[k][q] for k,q in zip(qreg, qubit)],
+                    "params":[[list(map(lambda z: [z.real, z.imag], row)) 
+                            for row in instruction.operation.params[0].tolist()]]
+                })
+
+            elif instruction.operation.name == "save_state":
+                json_data["instructions"].append({
+                    "name":instruction.operation.name, 
+                    "qubits":[quantum_registers[k][q] for k,q in zip(qreg, qubit)],
+                    "snapshot_type": instruction.operation._subtype,
+                    "label": instruction.operation.label
+                })
+            elif instruction.operation.name == "set_statevector":
+                json_data["instructions"].append({
                 "name":instruction.operation.name,
-                "qubits":[quantum_registers[k][q] for k,q in zip(qreg, qubit)],
-                "clbits":[classical_registers[k][b] for k,b in zip(clreg, bit)]
-            })
+                "qubits":list(range(sum([q.size for q in c.qregs]))),
+                "params": [
+                    list(map(lambda z: [z.real, z.imag],
+                    instruction.operation.params[0].tolist()))
+                    ]
+                })
 
-        elif instruction.operation.name == "unitary":
-            json_data["instructions"].append({
-                "name":instruction.operation.name, 
-                "qubits":[quantum_registers[k][q] for k,q in zip(qreg, qubit)],
-                "params":[[list(map(lambda z: [z.real, z.imag], row)) 
-                           for row in instruction.operation.params[0].tolist()]]
-            })
-
-        elif instruction.operation.name == "save_state":
-            json_data["instructions"].append({
-                "name":instruction.operation.name, 
-                "qubits":[quantum_registers[k][q] for k,q in zip(qreg, qubit)],
-                "snapshot_type": instruction.operation._subtype,
-                "label": instruction.operation.label
-            })
-        elif instruction.operation.name == "set_statevector":
-            json_data["instructions"].append({
-            "name":instruction.operation.name,
-            "qubits":list(range(sum([q.size for q in c.qregs]))),
-            "params": [
-                list(map(lambda z: [z.real, z.imag],
-                instruction.operation.params[0].tolist()))
-                ]
-            })
-
-        elif instruction.operation.name == "if_else":
-            json_data["is_dynamic"] = True
-
-            if not any([sub_circuit is None for sub_circuit in instruction.operation.params]):
-                raise ValueError("if_else instruction with \'else\' case is not supported for the "
-                                 "current version.")
-            else:
-                sub_circuit = [
-                    sub_circuit for sub_circuit in instruction.operation.params 
-                    if sub_circuit is not None
-                ][0]
-
-
-            if (condition := instruction.condition[1]) not in [0, 1]:
-                raise ValueError("Only 0 or 1 are accepted as conditions for classically controlled "
-                                "operations for the current version.")
-            
-            for re in c.qregs:
-                sub_circuit.add_register(re)
-
-            sub_instructions = to_ir(sub_circuit)["instructions"]
-
-            cc_instruction = {
-                "name": "cif",
-                "clbits": [classical_registers[k][b] for k,b in zip(clreg, bit)],
-                "instructions": sub_instructions,
-                "condition": condition
-                }
-            
-            json_data["instructions"].append(cc_instruction)
-
-        else:
-
-            instruction_params = [
-                str(param) if (isinstance(param, Parameter) or isinstance(param, Parameter)) else param 
-                for param in instruction.operation.params
-            ]
-        
-            instr = {"name":instruction.operation.name, 
-                     "qubits":[quantum_registers[k][q] for k,q in zip(qreg, qubit)],
-                     "params":instruction_params
-                    }
-            
-            if instruction.operation.condition != None:
-
-                if instruction.operation._condition[1] not in [1]:
-                    raise ValueError("Only 1 is accepted as condition for classicaly controlled "
-                                     "operations for the current version.")
-                    
-                name = instruction.operation.condition[0]._register.name
-                index = instruction.operation.condition[0]._index
-                cc_clbit = classical_registers[name][index]
-
+            elif instruction.operation.name == "if_else":
                 json_data["is_dynamic"] = True
-                json_data["instructions"].append({"name":"cif",
-                                            "clbits":[cc_clbit],
-                                            "instructions":[instr]
-                                            })
-            
-            else:
-                json_data["instructions"].append(instr)
 
-    return json_data
+                if not any([sub_circuit is None for sub_circuit in instruction.operation.params]):
+                    raise ValueError("if_else instruction with \'else\' case is not supported for the "
+                                    "current version.")
+                else:
+                    sub_circuit = [
+                        sub_circuit for sub_circuit in instruction.operation.params 
+                        if sub_circuit is not None
+                    ][0]
+
+
+                if (condition := instruction.condition[1]) not in [0, 1]:
+                    raise ValueError("Only 0 or 1 are accepted as conditions for classically controlled "
+                                    "operations for the current version.")
+                
+                for re in c.qregs:
+                    sub_circuit.add_register(re)
+
+                sub_instructions = to_ir(sub_circuit)["instructions"]
+
+                cc_instruction = {
+                    "name": "cif",
+                    "clbits": [classical_registers[k][b] for k,b in zip(clreg, bit)],
+                    "instructions": sub_instructions,
+                    "condition": condition
+                    }
+                
+                json_data["instructions"].append(cc_instruction)
+
+            else:
+
+                instruction_params = [
+                    str(param) if (isinstance(param, Parameter) or isinstance(param, Parameter)) else param 
+                    for param in instruction.operation.params
+                ]
+            
+                instr = {"name":instruction.operation.name, 
+                        "qubits":[quantum_registers[k][q] for k,q in zip(qreg, qubit)],
+                        "params":instruction_params
+                        }
+                
+                if instruction.operation.condition != None:
+
+                    if instruction.operation._condition[1] not in [1]:
+                        raise ValueError("Only 1 is accepted as condition for classicaly controlled "
+                                        "operations for the current version.")
+                        
+                    name = instruction.operation.condition[0]._register.name
+                    index = instruction.operation.condition[0]._index
+                    cc_clbit = classical_registers[name][index]
+
+                    json_data["is_dynamic"] = True
+                    json_data["instructions"].append({"name":"cif",
+                                                "clbits":[cc_clbit],
+                                                "instructions":[instr]
+                                                })
+                
+                else:
+                    json_data["instructions"].append(instr)
+
+        return json_data

--- a/cunqa/constants.py.in
+++ b/cunqa/constants.py.in
@@ -2,4 +2,6 @@ QPUS_FILEPATH = "@QPUS_FILEPATH@"
 CUNQA_PATH = "@CUNQA_PATH@"
 LIBS_DIR = "@CMAKE_INSTALL_RPATH@"
 
+CUNQA_USE_QISKIT_PY = @CUNQA_USE_QISKIT_PY@
+
 REMOTE_GATES = ["send", "recv", "qsend", "qrecv", "expose", "rcontrol"]

--- a/cunqa/qpu.py
+++ b/cunqa/qpu.py
@@ -23,7 +23,6 @@ from typing import Union, Any, Optional, TypedDict
 from sympy import Symbol
 
 from collections import Counter
-from qiskit import QuantumCircuit
 
 from cunqa.qclient import QClient
 from cunqa.circuit import CunqaCircuit, to_ir
@@ -140,7 +139,7 @@ class QPU:
 
 
 def run(
-        circuits: Union[list[Union[dict, QuantumCircuit, CunqaCircuit]], Union[dict, QuantumCircuit, CunqaCircuit]], 
+        circuits: Union[list[Union[dict, 'QuantumCircuit', CunqaCircuit]], Union[dict, 'QuantumCircuit', CunqaCircuit]], 
         qpus: Union[list[QPU], QPU], 
         param_values: Union[dict[Symbol, Union[float, int]], list[Union[float, int]]] = None,
         **run_args: Any


### PR DESCRIPTION
## Actions Taken

- Removed the import of `QuantumCircuit` in `qpu.py`, as it was only required for Python type hints.
- Updated `ir.py` to conditionally import Qiskit based on the `CUNQA_USE_QISKIT_PY` variable.
  - This variable is set to `True` or `False` depending on the user's build-time configuration.
  - By default, it is set to `True`, meaning Qiskit support in `ir.py` is enabled by default.